### PR TITLE
NEX-16: add preview to the mostly automated setup of the project locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Follow these steps to get started:
 1. `cd next`
 2. `npm install`
 3. `cp .env.example .env.local`
+4. back in the drupal directory, execute `lando drush wunder_next:setup-user-and-consumer`
+5. copy the lines that the command outputs into your `.env.local` file in the next directory.
 4. `npm run dev`
 5. visit `localhost:3000` and you should see your content displayed by the frontend.
+6. you will also be able to view unpublished content as previews inside drupal.
 > If you get a `https://next4drupal-project.lndo.site/jsonapi failed, reason: unable to verify the first certificate`,
   decomment the `NODE_TLS_REJECT_UNAUTHORIZED=0` line in .env.local

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Follow these steps to get started:
 1. `cd drupal`
 2. `lando start`
 3. `lando composer install`
+4. generate oauth keys using the command `lando generate-oauth-keys`. The keys will be created in the `drupal/oauth` directory.
 4. Install Drupal as usual. Use the standard installation profile. You can do it via the UI or using this command: `lando drush si --site-name="My great site neame here"
-5. Configure the next drupal module by issuing the command:  `lando install-recipe wunder_next_setup`
+5. Run the `lando install-recipe wunder_next_setup` command to set up the `next` drupal module
 6. You can now export your configuration.
 7. Create some content :-)
 
@@ -31,13 +32,14 @@ All next.js code  is in the `next` directory.
 
 Follow these steps to get started:
 
-1. `cd next`
-2. `npm install`
+1. start in the `drupal` directory, and execute the command: `lando drush wunder_next:setup-user-and-consumer`
+2. `cd ../next`
 3. `cp .env.example .env.local`
-4. back in the drupal directory, execute `lando drush wunder_next:setup-user-and-consumer`
-5. copy the lines that the command outputs into your `.env.local` file in the next directory.
-4. `npm run dev`
-5. visit `localhost:3000` and you should see your content displayed by the frontend.
-6. you will also be able to view unpublished content as previews inside drupal.
-> If you get a `https://next4drupal-project.lndo.site/jsonapi failed, reason: unable to verify the first certificate`,
-  decomment the `NODE_TLS_REJECT_UNAUTHORIZED=0` line in .env.local
+4. add the output of the command in step 1 to your `.env.local` file and save it.
+5. `npm install`
+6. `npm run dev`
+7. visit `localhost:3000` and you should see your content displayed by the frontend.
+8. when viewing a piece of content inside Drupal, you should be able to preview it in the frontend, including unpublished content and revisions.
+
+> NOTE: If you get a `https://next4drupal-project.lndo.site/jsonapi failed, reason: unable to verify the first certificate`,
+decomment the `NODE_TLS_REJECT_UNAUTHORIZED=0` line in .env.local

--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -41,6 +41,13 @@ tooling:
     dir: /app/web
     user: www-data
 
+  generate-oauth-keys:
+    description: 'Generates a pair of public and private keys into the oauth directory'
+    cmd:
+      - appserver: /app/.lando/generate_oauth_keys.sh
+    dir: /app/oauth
+    user: www-data
+
 services:
   database:
     # User random static high port for database connection.

--- a/drupal/.lando/generate_oauth_keys.sh
+++ b/drupal/.lando/generate_oauth_keys.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Helper script to generate oath keys as part of the next4drupal setup.
+#
+# Usage:
+# lando generate-oauth-keys
+#
+
+openssl genrsa -out private.key 2048
+openssl rsa -in private.key -pubout > public.key

--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -22,7 +22,7 @@
         "drupal/core-composer-scaffold": "^9.3",
         "drupal/core-recommended": "^9.3",
         "drupal/monolog": "^2.0",
-        "drupal/next": "^1.3",
+        "drupal/next": "^1.4",
         "drupal/simplei": "^1.2",
         "drupal/warden": "^3.0@RC",
         "drush/drush": "^11.0",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a7faa7acfddbe261028d4666f8c46358",
+    "content-hash": "ac0b727c66f5d745f9666abe7c957f2e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1961,17 +1961,17 @@
         },
         {
             "name": "drupal/next",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/next.git",
-                "reference": "1.3.1"
+                "reference": "1.4.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/next-1.3.1.zip",
-                "reference": "1.3.1",
-                "shasum": "385aa0540eedbdd61e159bf9a9085a5fa7102aab"
+                "url": "https://ftp.drupal.org/files/projects/next-1.4.0.zip",
+                "reference": "1.4.0",
+                "shasum": "66afcf0dc78d43b3352868abbd8c2cd9789ba0f6"
             },
             "require": {
                 "cweagans/composer-patches": "~1.0",
@@ -1983,6 +1983,8 @@
             },
             "require-dev": {
                 "drupal/decoupled_router": "*",
+                "drupal/graphql": "*",
+                "drupal/graphql_compose": "*",
                 "drupal/jwt": "*",
                 "drupal/jwt_auth_consumer": "*",
                 "drupal/subrequests": "*",
@@ -1991,8 +1993,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "1.3.1",
-                    "datestamp": "1666009672",
+                    "version": "1.4.0",
+                    "datestamp": "1668079680",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.article.yml
+++ b/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.article.yml
@@ -1,0 +1,10 @@
+uuid: b004b8b0-55c4-4e82-9190-163c2e846f3e
+langcode: en
+status: true
+dependencies: {  }
+id: node.article
+site_resolver: site_selector
+configuration:
+  sites:
+    next_js_localhost: next_js_localhost
+  field_name: {  }

--- a/drupal/recipes/wunder_next_setup/config/next.next_site.next_js_localhost.yml
+++ b/drupal/recipes/wunder_next_setup/config/next.next_site.next_js_localhost.yml
@@ -1,0 +1,8 @@
+uuid: 0d9144f8-6739-4594-b701-05ae9b54e633
+langcode: en
+status: true
+dependencies: {  }
+id: next_js_localhost
+label: 'Next.js localhost'
+base_url: 'http://localhost:3000'
+preview_url: 'http://localhost:3000/api/preview'

--- a/drupal/recipes/wunder_next_setup/config/simple_oauth.settings.yml
+++ b/drupal/recipes/wunder_next_setup/config/simple_oauth.settings.yml
@@ -1,0 +1,9 @@
+access_token_expiration: 300
+authorization_code_expiration: 300
+refresh_token_expiration: 1209600
+token_cron_batch_size: 0
+public_key: ../oauth/public.key
+private_key: ../oauth/private.key
+remember_clients: true
+use_implicit: false
+disable_openid_connect: false

--- a/drupal/recipes/wunder_next_setup/config/user.role.next_api_role.yml
+++ b/drupal/recipes/wunder_next_setup/config/user.role.next_api_role.yml
@@ -1,0 +1,15 @@
+uuid: cdde3d87-907c-4a64-bede-812b1583a0be
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - subrequests
+id: next_api_role
+label: next_api_role
+weight: 4
+is_admin: null
+permissions:
+  - 'access user profiles'
+  - 'bypass node access'
+  - 'issue subrequests'

--- a/drupal/recipes/wunder_next_setup/recipe.yml
+++ b/drupal/recipes/wunder_next_setup/recipe.yml
@@ -6,3 +6,4 @@ install:
   - next
   - next_jsonapi
   - pathauto
+  - wunder_next

--- a/drupal/web/modules/custom/wunder_next/composer.json
+++ b/drupal/web/modules/custom/wunder_next/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "org/wunder_next",
+    "type": "drupal-drush",
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^11"
+            }
+        }
+    }
+}

--- a/drupal/web/modules/custom/wunder_next/drush.services.yml
+++ b/drupal/web/modules/custom/wunder_next/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+  wunder_next.commands:
+    class: \Drupal\wunder_next\Commands\WunderNextCommands
+    tags:
+      - { name: drush.command }

--- a/drupal/web/modules/custom/wunder_next/src/Commands/WunderNextCommands.php
+++ b/drupal/web/modules/custom/wunder_next/src/Commands/WunderNextCommands.php
@@ -54,7 +54,7 @@ class WunderNextCommands extends DrushCommands {
       // Check if the account can be created:
       if ($violations->count() > 0) {
         foreach ($violations as $violation) {
-          $this->output()->writeln('<error>' . $violation->getMessage() . '<error>');
+          $this->logger()->error($violation->getMessage());
           return new CommandError("Could not create a new user account with the name " . self::API_USER_NAME . ".");
         }
       }
@@ -79,7 +79,7 @@ class WunderNextCommands extends DrushCommands {
       // Check if the consumer can be created:
       if ($violations->count() > 0) {
         foreach ($violations as $violation) {
-          $this->output()->writeln('<error>' . $violation->getMessage() . '<error>');
+          $this->logger()->error($violation->getMessage());
           return new CommandError('Could not create a new consumer.');
         }
       }
@@ -92,7 +92,7 @@ class WunderNextCommands extends DrushCommands {
     $uuid = $consumer->uuid();
 
     // Output instructions to the user:
-    $this->output()->writeln('User and consumer are now created. Add these two lines to the .env file for the Next application:');
+    $this->logger()->success(dt('User and consumer created. Add these two lines to the .env file for the Next application:'));
     $this->output()->writeln("DRUPAL_CLIENT_ID=$uuid");
     $this->output()->writeln("DRUPAL_CLIENT_SECRET=$secret");
   }

--- a/drupal/web/modules/custom/wunder_next/src/Commands/WunderNextCommands.php
+++ b/drupal/web/modules/custom/wunder_next/src/Commands/WunderNextCommands.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\wunder_next\Commands;
+
+use Consolidation\AnnotatedCommand\CommandError;
+use Drupal\Core\Entity\EntityStorageException;
+use Drupal\user\Entity\User;
+use Drush\Commands\DrushCommands;
+use Drupal\consumers\Entity\Consumer;
+
+/**
+ * A Drush commandfile.
+ *
+ */
+class WunderNextCommands extends DrushCommands {
+
+  const API_USER_NAME = 'next-api-user';
+  const API_USER_ROLE = 'next_api_role';
+  const API_USER_MAIL = 'next-api-user@domain.tld';
+
+  /**
+   * Generates a user and a consumer to be used to view next-drupal previews.
+   *
+   * @param array $options
+   *   An associative array of options whose values come from cli, aliases,
+   *   config, etc.
+   *
+   * @option secret
+   *   The secret to assign to the consumer
+   * @usage wunder_next-commandName --secret=somesecret
+   *   Use the --secret option to set the secret for the consumer, or leave
+   *   blank for a random value.
+   *
+   * @command wunder_next:setup-user-and-consumer
+   * @aliases wnsuac
+   */
+  public function setupUserAndConsumer(array $options = ['secret' => '']) {
+
+    $secret = $options['secret'] ?: base64_encode(random_bytes('20'));
+
+    // Create a new user with the required role:
+    $new_user = [
+      'name' => self::API_USER_NAME,
+      'pass' => '',
+      'mail' => self::API_USER_MAIL,
+      'access' => '0',
+      'status' => 1,
+      'roles' => [self::API_USER_ROLE],
+    ];
+
+    $account = User::create($new_user);
+    try {
+      $violations = $account->validate();
+      // Check if the account can be created:
+      if ($violations->count() > 0) {
+        foreach ($violations as $violation) {
+          $this->output()->writeln('<error>' . $violation->getMessage() . '<error>');
+          return new CommandError("Could not create a new user account with the name " . self::API_USER_NAME . ".");
+        }
+      }
+      $account->save();
+    } catch (EntityStorageException $e) {
+      return new CommandError("Could not create a new user account with the name " . self::API_USER_NAME . ".");
+    }
+
+    /** @var Consumer $consumer */
+    $consumer = Consumer::create([
+      'client_id' => 'next-drupal-consumer',
+      'label' => 'Consumer for next-drupal',
+      'description' => 'This consumer was created by the wunder_next:create-user-and-consumer drush command.',
+      'is_default' => FALSE,
+      'user_id' => $account->id(),
+      'roles' => [self::API_USER_ROLE],
+      'secret' => $secret,
+    ]);
+
+    try {
+      $violations = $consumer->validate();
+      // Check if the consumer can be created:
+      if ($violations->count() > 0) {
+        foreach ($violations as $violation) {
+          $this->output()->writeln('<error>' . $violation->getMessage() . '<error>');
+          return new CommandError('Could not create a new consumer.');
+        }
+      }
+
+      $consumer->save();
+    } catch (EntityStorageException $e) {
+      return new CommandError('Could not create a new consumer.');
+    }
+
+    $uuid = $consumer->uuid();
+
+    // Output instructions to the user:
+    $this->output()->writeln('User and consumer are now created. Add these two lines to the .env file for the Next application:');
+    $this->output()->writeln("DRUPAL_CLIENT_ID=$uuid");
+    $this->output()->writeln("DRUPAL_CLIENT_SECRET=$secret");
+  }
+
+}

--- a/drupal/web/modules/custom/wunder_next/wunder_next.info.yml
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.info.yml
@@ -1,0 +1,7 @@
+name: wunder_next
+type: module
+description: Provides additional functionality to use and setup next4drupal
+package: Custom
+core_version_requirement: ^9 || ^10
+dependencies:
+  - next

--- a/next/.env.example
+++ b/next/.env.example
@@ -7,6 +7,3 @@ NEXT_IMAGE_DOMAIN=next4drupal-project.lndo.site
 # Add here the id of the drupal consumer, and the value of the secret:
 DRUPAL_CLIENT_ID=id_of_the_consumer
 DRUPAL_CLIENT_SECRET=secret
-
-# Required for Preview Mode
-DRUPAL_PREVIEW_SECRET=secret

--- a/next/lib/drupal.ts
+++ b/next/lib/drupal.ts
@@ -3,7 +3,7 @@ import { DrupalClient } from "next-drupal"
 export const drupal = new DrupalClient(
   process.env.NEXT_PUBLIC_DRUPAL_BASE_URL,
   {
-    previewSecret: process.env.DRUPAL_PREVIEW_SECRET,
+    forceIframeSameSiteCookie: process.env.NODE_ENV === "development",
     auth: {
       clientId: process.env.DRUPAL_CLIENT_ID,
       clientSecret: process.env.DRUPAL_CLIENT_SECRET,


### PR DESCRIPTION
This branch adds instructions and automation to set up preview mode when kicking off a project using this starter, using a combination of a drupal recipe and a custom module that provides a drush command to set some parts up.

Following the instructions[ on the next-drupal website](https://next-drupal.org/learn/preview-mode), these are the steps needed: 

1. https://next-drupal.org/learn/preview-mode/create-site > added the site entity to the recipe
2. https://next-drupal.org/learn/preview-mode/create-oauth-client
   * role with permission -> added role and permissions to the recipe
   * key generation -> added lando script that generates the keys in the correct directory
   * creation of a user and the consumer connected to that user -> added a custom module with a drush command that creates the user, a random secret and the needed consumer, gives out the lines that need to be added to .env.local in next
3. Configure preview routes -> included in the starter we are using
4. https://next-drupal.org/learn/preview-mode/configure-content-types
   * this is done with configuration, so I have added this to the recipe.
   
   
To test: 

* follow the updated README from scratch, and you should be able to preview content, including unpublished content from within drupal.


(This handles the local development, we will still need to figure out how to make this work in silta etc.   
   
   
   