### PR TITLE
NEX-19: Add mechanism to make the frontend url in drupal tied to an env var

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -58,6 +58,8 @@ services:
       - "composer install"
     overrides:
       environment:
+        # URL OF THE FRONTEND SITE:
+        WUNDER_NEXT_FRONTEND_URL: http://localhost:3000
         HASH_SALT: notsosecurehashnotsosecurehashnotsosecurehash
         ENVIRONMENT_NAME: lando
         DB_NAME_DRUPAL: drupal9

--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Main module file for wunder_next.
+ */
+
+use Drupal\Core\Site\Settings;
+
+/**
+ * Implements hook_ENTITY_TYPE_load().
+ */
+function wunder_next_next_site_load($entities) {
+  // We want to override the configuration entity for the next site
+  // to set the frontend path based on our setting.
+  // The setting is then set according to an environment variable in
+  // settings.php.
+  $settings = Settings::get('wunder_next.settings');
+  // We expect one next site called "frontend", which we have added
+  // to the initial recipe.
+  foreach ($entities as $next_site) {
+    if ($next_site->id() == 'frontend') {
+      $next_site->setBaseUrl($settings['frontend_url']);
+      $next_site->setPreviewUrl($settings['frontend_url'] . '/api/preview');
+    }
+  }
+}

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -42,6 +42,9 @@ $settings['file_scan_ignore_directories'] = [
   'bower_components',
 ];
 
+// Get the url of the frontend from an environment variable:
+$settings['wunder_next.settings']['frontend_url'] = $_ENV['WUNDER_NEXT_FRONTEND_URL'];
+
 // Environment-specific settings.
 $env = $_ENV['ENVIRONMENT_NAME'];
 switch ($env) {


### PR DESCRIPTION
* added the env var to lando setup WUNDER_NEXT_FRONTEND_URL
* added setting to settings.php using the env var
* added implementation of hook_ENTITY_TYPE_load to set the value dynamically based on the setting


This implies that there's only one frontend site (but for the standard case that should be ok), and also that there's a frontend site with the id "frontend", but we are creating that as part of the recipe, so we can be confident that it's there.