### PR TITLE
NEX-26: Add revalidation feature

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -69,7 +69,12 @@ services:
     overrides:
       environment:
         # URL OF THE FRONTEND SITE:
-        WUNDER_NEXT_FRONTEND_URL: http://localhost:3000
+        # This needs to match the proxy value for the node service
+        # so if you change it, remember to change it here as well.
+        WUNDER_NEXT_FRONTEND_URL: https://frontend.lndo.site
+        # This same var is set in the node service below, the value should match.
+        # This is only used in local development so it can be a not secure value:
+        DRUPAL_REVALIDATE_SECRET: mysecret
         HASH_SALT: notsosecurehashnotsosecurehashnotsosecurehash
         ENVIRONMENT_NAME: lando
         DB_NAME_DRUPAL: drupal9
@@ -82,6 +87,20 @@ services:
         PHP_IDE_CONFIG: serverName=appserver
         # PHPUnit settings. @see: .lando/phpunit.sh
         MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'
+  node:
+    type: node:16
+    ssl: true
+    sslExpose: true
+    overrides:
+      ports:
+        - "3000:3000"
+      environment:
+        # This same var is set in the appserver service above, the value should match.
+        # This is only used in local development so it can be a not secure value:
+        DRUPAL_REVALIDATE_SECRET: mysecret
+    build:
+      - "cd next && npm install"
+    scanner: false
   chrome:
     type: compose
     services:
@@ -126,14 +145,6 @@ services:
     type: mailhog
     hogfrom:
       - appserver
-  node:
-    type: node:16
-    overrides:
-      ports:
-        - "3000:3000"
-    build:
-      - "cd next && npm install"
-    scanner: false
 
 proxy:
   mailhog:
@@ -143,6 +154,9 @@ proxy:
   # kibana:
   #   - kibana.lndo.site:5601
   node:
+  # This value is used by the appserver service to connect to the frontend
+  # so make sure that this value and the WUNDER_NEXT_FRONTEND_URL env var are
+  # in sync.
     - frontend.lndo.site:3000
 
 events:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This example is ready to be used together with the [Silta](https://wunderio.gith
 ### Lando setup
 
 Local development is handled by [Lando](https://lando.dev/). Both frontend and backend are covered by the Lando setup,
-so that is the only real requirement. 
+so that is the only real requirement. The frontend site can be run in either dev or prod mode, 
+and it will be proxied by lando at the configured url in lando. The default is [https://frontend.lndo.site](https://frontend.lndo.site)"
 
 ### Getting started
 
@@ -49,8 +50,9 @@ Follow these steps to get started:
 4. Add the output of the command in step 1 to the end of your newly created `.env.local` file and save it.
 5. `lando npm install`
 6. `lando npm run dev`
-7. Visit `localhost:3000` and you should see your content displayed by the frontend.
+7. Visit `https://frontend.lndo.site` and you should see your content displayed by the frontend.
 8. When viewing a piece of content inside Drupal, you should be able to preview it in the frontend, including unpublished content and revisions.
+9. The template includes automatic setup of [On demand revalidation](https://next-drupal.org/learn/on-demand-revalidation), so saving a piece of content will automatically revalidate the corresponding path in next.js.
 
 > NOTE: If you get ar error message saying `https://next4drupal-project.lndo.site/jsonapi failed, reason: unable to verify the first certificate`,
 decomment the `NODE_TLS_REJECT_UNAUTHORIZED=0` line in .env.local

--- a/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.article.yml
+++ b/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.article.yml
@@ -7,7 +7,7 @@ configuration:
   sites:
     frontend: frontend
   field_name: {  }
-revalidator: ''
+revalidator: path
 revalidator_configuration:
-  revalidate_page: null
-  additional_paths: null
+  revalidate_page: true
+  additional_paths: "/\r\n/fi\r\n/en\r\n/sv"

--- a/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.landing_page.yml
+++ b/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.landing_page.yml
@@ -7,5 +7,7 @@ configuration:
   sites:
     frontend: frontend
   field_name: {  }
-revalidator: ''
-revalidator_configuration: {  }
+revalidator: path
+revalidator_configuration:
+  revalidate_page: true
+  additional_paths: ''

--- a/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.page.yml
+++ b/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.page.yml
@@ -6,5 +6,7 @@ site_resolver: site_selector
 configuration:
   sites:
     frontend: frontend
-revalidator: ''
-revalidator_configuration: {  }
+revalidator: path
+revalidator_configuration:
+  revalidate_page: true
+  additional_paths: ''

--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -23,6 +23,7 @@ function wunder_next_next_site_load($entities) {
       $next_site->setBaseUrl($settings['frontend_url']);
       $next_site->setPreviewUrl($settings['frontend_url'] . '/api/preview');
       $next_site->setRevalidateUrl($settings['frontend_url'] . '/api/revalidate');
+      $next_site->setRevalidateSecret($settings['revalidate_secret']);
     }
   }
 }

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -44,6 +44,7 @@ $settings['file_scan_ignore_directories'] = [
 
 // Get the url of the frontend from an environment variable:
 $settings['wunder_next.settings']['frontend_url'] = $_ENV['WUNDER_NEXT_FRONTEND_URL'];
+$settings['wunder_next.settings']['revalidate_secret'] = $_ENV['DRUPAL_REVALIDATE_SECRET'];
 
 // Environment-specific settings.
 $env = $_ENV['ENVIRONMENT_NAME'];

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -112,5 +112,6 @@ export async function getStaticProps(
         ["common"]
       )),
     },
+    revalidate: 60,
   };
 }

--- a/next/pages/api/revalidate.ts
+++ b/next/pages/api/revalidate.ts
@@ -8,7 +8,7 @@ export default async function handler(
   const secret = request.query.secret as string;
 
   // Validate secret.
-  if (secret !== process.env.DRUPAL_PREVIEW_SECRET) {
+  if (secret !== process.env.DRUPAL_REVALIDATE_SECRET) {
     return response.status(401).json({ message: "Invalid secret." });
   }
 

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -73,5 +73,6 @@ export async function getStaticProps(
       menus: await getMenus(context),
       ...(await serverSideTranslations(context.locale, ["common"])),
     },
+    revalidate: 60,
   };
 }


### PR DESCRIPTION
*Link to ticket: [NEX-26](https://wunder.atlassian.net/browse/NEX-26)*

This PR adds [incremental static regeneration](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration) and [On demand revalidation](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#on-demand-revalidation) to our setup.

To make this work, this PR adds: 

* revalidate property for the index and slug pages
* telling drupal to use the lando proxied path for frontend "https://frontend.lndo.site" instead of the localhost:3000  (so this the url that will be used for revalidation and also for iframes inside the site
* adding the new env var "DRUPAL_REVALIDATE_SECRET"
* setting content types's property for revalidation

### A note on revalidation

This mechanism is pretty rudimentary compared to drupal's cache clearing. For example, I have set the path of the frontpage (for all languages) as a path to be revalidated for article pages. But, any content can be added to the menu, which is then shown on all pages: there is no way (that could find) to revalidate the whole site when a menu item changes, for example. So I have set the revalidate option for all pages, so after 60 seconds they will be regenerated again (and then served with the stale-while-revalidated method)

### Impact on silta (which is in progress) 

@tharna this branch adds a new env var called `DRUPAL_REVALIDATE_SECRET` that should be present and have the same value both for drupal and next in silta. Also there's this info on next.js's site about running this in kubernetes https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#self-hosting-isr

*How to test:*
1. do the setup from scratch, *including lando rebuild, since we changed some of the lando setup in this branch* 
You can use this one line command to speed things up: 
```
lando rebuild -y && lando composer install && lando generate-oauth-keys && lando drush si --site-name="My great site name here" -y && lando install-recipe wunder_next_setup && lando drush wunder_next:setup-user-and-consumer
```
2. copy the secrets like always to the `.env.local` file
3.  to test revalidation, you have to create a production build and run the server in production mode [like they say on next.js' website](https://nextjs.org/docs/basic-features/data-fetching/incremental-static-regeneration#testing-on-demand-isr-during-development) so run: 
```
lando npm run build
lando  npm run start
```
4. create some content
5. visit the site at https://frontend.lndo.site, not in preview mode (you can open the site in a private window to be sure
6. create an article
7. see that it appears at the forntpage of the site, and you can navigate into it
8. update the article, you should be able to see the changes straight away if you reload the page in the browser
9. create a new article, the homepage should update right away.
> starting from this PR, we should not use localhost:3000 but instead https://frontend.lndo.site to access the site