### PR TITLE
NEX-31: Add partial support for redirects

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -25,6 +25,7 @@
         "drupal/monolog": "^2.0",
         "drupal/next": "^1.6",
         "drupal/paragraphs": "^1.15",
+        "drupal/redirect": "^1.8",
         "drupal/simplei": "^1.2",
         "drupal/warden": "^3.0@RC",
         "drush/drush": "^11.0",
@@ -122,7 +123,7 @@
                 "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
             },
             "drupal/decoupled_router": {
-                "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2021-05-05/3111456-34.patch"
+                "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-12-01/decouple_router-3111456-resolve-language-issue-58--get-translation.patch"
             },
             "drupal/core": {
                 "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe.patch",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a14983284c4b1021367b1e023b380af",
+    "content-hash": "fcec14722873b7df03e7cee6fdc86a8b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1842,29 +1842,29 @@
         },
         {
             "name": "drupal/decoupled_router",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/decoupled_router.git",
-                "reference": "2.0.3"
+                "reference": "2.0.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/decoupled_router-2.0.3.zip",
-                "reference": "2.0.3",
-                "shasum": "3e494c9d76c55d2f29eedffd1ab0c68c7224be27"
+                "url": "https://ftp.drupal.org/files/projects/decoupled_router-2.0.4.zip",
+                "reference": "2.0.4",
+                "shasum": "8dacb4460c93a3fa9b034516a7e1caaf254be76b"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^8.8 || ^9 || ^10"
             },
             "require-dev": {
-                "drupal/redirect": "^1.0@beta"
+                "drupal/redirect": "^1.8"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.3",
-                    "datestamp": "1631977518",
+                    "version": "2.0.4",
+                    "datestamp": "1669803945",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2421,6 +2421,58 @@
                 "source": "https://cgit.drupalcode.org/pathauto",
                 "issues": "https://www.drupal.org/project/issues/pathauto",
                 "documentation": "https://www.drupal.org/docs/8/modules/pathauto"
+            }
+        },
+        {
+            "name": "drupal/redirect",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/redirect.git",
+                "reference": "8.x-1.8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.8.zip",
+                "reference": "8.x-1.8",
+                "shasum": "a7a440423434472ff7115ae69df01553f763f839"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.8",
+                    "datestamp": "1661806955",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Berdir",
+                    "homepage": "https://www.drupal.org/user/214652"
+                },
+                {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
+                    "name": "pifagor",
+                    "homepage": "https://www.drupal.org/user/2375692"
+                }
+            ],
+            "description": "Allows users to redirect from old URLs to new URLs.",
+            "homepage": "https://www.drupal.org/project/redirect",
+            "support": {
+                "source": "https://git.drupalcode.org/project/redirect"
             }
         },
         {

--- a/drupal/recipes/wunder_next_setup/config/redirect.settings.yml
+++ b/drupal/recipes/wunder_next_setup/config/redirect.settings.yml
@@ -1,0 +1,7 @@
+auto_redirect: false
+default_status_code: 301
+passthrough_querystring: true
+warning: false
+ignore_admin_path: false
+access_check: false
+route_normalizer_enabled: true

--- a/drupal/recipes/wunder_next_setup/recipe.yml
+++ b/drupal/recipes/wunder_next_setup/recipe.yml
@@ -10,3 +10,7 @@ install:
   - pathauto
   - wunder_next
   - jsonapi_menu_items
+  - redirect
+config:
+  import:
+    redirect: '*'

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -64,9 +64,19 @@ export async function getStaticProps(
 ): Promise<GetStaticPropsResult<NodePageProps>> {
   const path = await drupal.translatePathFromContext(context);
 
-  if (!path || !RESOURCE_TYPES.includes(path.jsonapi.resourceName)) {
+  if (!path) {
     return {
       notFound: true,
+    };
+  }
+
+  if (path.redirect?.length) {
+    const [redirect] = path.redirect;
+    return {
+      redirect: {
+        destination: redirect.to,
+        permanent: false,
+      },
     };
   }
 


### PR DESCRIPTION
Support for redirects with multilingual setups seem to be a problematic area for this setup. I have written a message in the official slack: https://drupal.slack.com/archives/C01E36BMU72/p1671781046005709 


This PR adds partial support for redirects, with these limitations:

1. redirects need to be created manually, we cannot use the "Automatically create redirects when URL aliases are changed." `/admin/config/search/redirect/settings`, so that is disabled in the recipe
2. no redirects to external urls (https://www.drupal.org/project/decoupled_router/issues/3133681 old patch, won't apply)
3.  English redirects (or default language redirects) need to be marked for all languages
4.  language specific redirects need to be marked for that language


*Link to ticket: https://wunder.atlassian.net/browse/NEX-31*

*How to test:*

1. set the project up from scratch, following the instructions in https://github.com/wunderio/next4drupal-project/blob/feature/NEX-31/README.md 

### Redirects in default language

1. create an article with the title "test article" in English. It will get the path `/en/blog/test-article`
2. visit `https://next4drupal-project.lndo.site/en/admin/config/search/redirect/add` and add a redirect to the article like this: 
![image](https://user-images.githubusercontent.com/185412/209295907-e32ee289-abd6-41ce-9821-a720aff12a11.png)

3. visit `https://frontend.lndo.site/en/redirected-path` or `https://frontend.lndo.site/redirected-path` and verify that you are redirected to `https://frontend.lndo.site/en/blog/test-article`


### Redirects in a non-default language

1. create an article with the title "test article finnish" in Finnish. It will get the path `/fi/blog/test-article-finnish` 
2. visit `https://next4drupal-project.lndo.site/fi/admin/config/search/redirect/add` and add a redirect to the article like this: 

![image](https://user-images.githubusercontent.com/185412/209296939-5ea633d1-cd9c-4bf4-b802-311e1db88756.png)

3. visit `https://frontend.lndo.site/fi/redirected-path-finnish` and verify that you are redirected to `https://frontend.lndo.site/fi/blog/test-article-finnish`

