### PR TITLE
Feature/nex 34 link fields

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -130,7 +130,8 @@
             "drupal/core": {
                 "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe.patch",
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch",
-                "Set MenuLinkContent getEntity to public visibility": "https://www.drupal.org/files/issues/2022-05-16/2997790-40.patch"
+                "Set MenuLinkContent getEntity to public visibility": "https://www.drupal.org/files/issues/2022-05-16/2997790-40.patch",
+                "Add link fields to jsonapi response": "https://www.drupal.org/files/issues/2022-03-04/3066751-68.patch"
             },
             "drupal/jsonapi_menu_items": {
                 "Add info about the langcode for menu items (issue #3192576)": "https://git.drupalcode.org/project/jsonapi_menu_items/-/merge_requests/7.diff"

--- a/drupal/recipes/wunder_landing_pages/config/core.entity_form_display.paragraph.links.default.yml
+++ b/drupal/recipes/wunder_landing_pages/config/core.entity_form_display.paragraph.links.default.yml
@@ -1,0 +1,25 @@
+uuid: 23bced58-4188-44ef-8824-4c6e22d7b956
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.links.field_links
+    - paragraphs.paragraphs_type.links
+  module:
+    - link
+id: paragraph.links.default
+targetEntityType: paragraph
+bundle: links
+mode: default
+content:
+  field_links:
+    type: link_default
+    weight: 0
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/drupal/recipes/wunder_landing_pages/config/core.entity_view_display.paragraph.links.default.yml
+++ b/drupal/recipes/wunder_landing_pages/config/core.entity_view_display.paragraph.links.default.yml
@@ -1,0 +1,27 @@
+uuid: 8ca3dcfd-5482-4a74-8ded-d0ea01fa1bcf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.links.field_links
+    - paragraphs.paragraphs_type.links
+  module:
+    - link
+id: paragraph.links.default
+targetEntityType: paragraph
+bundle: links
+mode: default
+content:
+  field_links:
+    type: link
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden: {  }

--- a/drupal/recipes/wunder_landing_pages/config/field.field.paragraph.links.field_links.yml
+++ b/drupal/recipes/wunder_landing_pages/config/field.field.paragraph.links.field_links.yml
@@ -1,0 +1,23 @@
+uuid: 48722a2c-9456-4a94-9b54-f5acaa347931
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_links
+    - paragraphs.paragraphs_type.links
+  module:
+    - link
+id: paragraph.links.field_links
+field_name: field_links
+entity_type: paragraph
+bundle: links
+label: Links
+description: 'Add a list of links.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  title: 2
+  link_type: 17
+field_type: link

--- a/drupal/recipes/wunder_landing_pages/config/field.storage.paragraph.field_links.yml
+++ b/drupal/recipes/wunder_landing_pages/config/field.storage.paragraph.field_links.yml
@@ -1,0 +1,19 @@
+uuid: fb979ee7-b04e-45d5-9314-a50b30a4529d
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - paragraphs
+id: paragraph.field_links
+field_name: field_links
+entity_type: paragraph
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/drupal/recipes/wunder_landing_pages/config/paragraphs.paragraphs_type.links.yml
+++ b/drupal/recipes/wunder_landing_pages/config/paragraphs.paragraphs_type.links.yml
@@ -1,0 +1,10 @@
+uuid: f796b11e-aa74-4bcd-ad8c-db3b2bbd8894
+langcode: en
+status: true
+dependencies: {  }
+id: links
+label: Links
+icon_uuid: null
+icon_default: null
+description: 'a paragraph type containing a list of links.'
+behavior_plugins: {  }

--- a/next/components/paragraph--links.tsx
+++ b/next/components/paragraph--links.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+import { Key } from "react";
+import { ParagraphProps } from "components/paragraph";
+
+type Link = {
+  full_url: string;
+  url: string;
+  title: string;
+};
+
+export function ParagraphLinks({ paragraph }: ParagraphProps) {
+  return (
+    <ul className="list-disc p-2">
+      {paragraph.field_links.map((link: Link, id: Key) => (
+        <li key={id}>
+          <Link className="text-sm text-wunderpurple-600" href={link.full_url}>
+            {link.title}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/next/components/paragraph.tsx
+++ b/next/components/paragraph.tsx
@@ -1,5 +1,6 @@
 import { DrupalParagraph } from "next-drupal";
 import { ParagraphImage } from "components/paragraph--image";
+import { ParagraphLinks } from "components/paragraph--links";
 import { ParagraphText } from "components/paragraph--text";
 import { ParagraphVideo } from "components/paragraph--video";
 
@@ -7,6 +8,7 @@ const paragraphTypes = {
   "paragraph--formatted_text": ParagraphText,
   "paragraph--image": ParagraphImage,
   "paragraph--video": ParagraphVideo,
+  "paragraph--links": ParagraphLinks,
 };
 
 export interface ParagraphProps {


### PR DESCRIPTION
This feature adds: 

* a patch to be able to get full urls in the jsonapi response, more info here: https://www.drupal.org/node/3066751
* a Links paragraph, that can be added to the landing page content type
* the frontend component to display the link as a simple unordered list

### To test


1. Set up the project as described in the readme, or you can also just run this one command: 
```
lando rebuild -y && lando composer install && lando generate-oauth-keys && lando drush si --site-name="My great site name here" -y && lando install-recipe wunder_next_setup && lando drush wunder_next:setup-user-and-consumer && lando drush eshd -y && lando drush eshs 
```
2. Make sure to add the generated api keys to the frontend's `.env.local`, 
3. start the frontend
4. log into the  backend, add a landing page, add a links paragraph to the node, save and verify that the links are displayed.

![image](https://user-images.githubusercontent.com/185412/212718040-95e7b74c-75ba-42ab-a3de-fa666edfa948.png)

![image](https://user-images.githubusercontent.com/185412/212718827-bb757841-f618-441c-b5cf-4bd8281074a3.png)



