### PR TITLE
NEX-30: Language switcher fixes

### DIFF
--- a/next/components/locale-switcher.tsx
+++ b/next/components/locale-switcher.tsx
@@ -10,20 +10,19 @@ export default function LocaleSwitcher() {
 
   const [open, setOpen] = useState(false);
   const toggleList = () => {
-    setOpen(!open)
-  }
+    setOpen(!open);
+  };
   const [language, setLanguage] = useState(activeLocale);
   const [languages, setLanguages] = useState(locales);
 
   const selectedLanguage = (locale) => {
-    setLanguage(locale)
+    setLanguage(locale);
     setOpen(false);
-  }
+  };
 
   useEffect(() => {
-    setLanguages(locales.filter(locale => locale != language))
-  }, [language])
-
+    setLanguages(locales.filter((locale) => locale != language));
+  }, [language]);
 
   return (
     <nav>
@@ -32,37 +31,66 @@ export default function LocaleSwitcher() {
         className="flex flex-1 relative p-2.5"
         onClick={toggleList}
       >
-        <div className={`${activeLocale === language ? "font-bold" : ""
-          } pr-3`}>{languageLinks[language]?.name} </div>
+        <div className={`${activeLocale === language ? "font-bold" : ""} pr-3`}>
+          {languageLinks[language]?.name}{" "}
+        </div>
         {/* icons from https://heroicons.com/  */}
-        {open && <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
-        </svg>}
-        {!open && <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="w-6 h-6">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-        </svg>}
+        {open && (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M4.5 15.75l7.5-7.5 7.5 7.5"
+            />
+          </svg>
+        )}
+        {!open && (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+            />
+          </svg>
+        )}
       </button>
-      {open && <ul className="block">
-        {languages.map(locale => {
-          return (
-            <li
-              className="px-3 py-1"
-              key={locale}
-              onClick={() => selectedLanguage(locale)}
-            >
-              <Link
-                href={languageLinks[locale].path}
-                as={languageLinks[locale].path}
-                locale={locale}
-                legacyBehavior
-                passHref
+      {open && (
+        <ul className="block">
+          {languages.map((locale) => {
+            return (
+              <li
+                className="px-3 py-1"
+                key={locale}
+                onClick={() => selectedLanguage(locale)}
               >
-                <a className="block">{languageLinks[locale]?.name}</a>
-              </Link>
-            </li>
-          );
-        })}
-      </ul>}
+                <Link
+                  href={languageLinks[locale].path}
+                  as={languageLinks[locale].path}
+                  locale={locale}
+                  legacyBehavior
+                  passHref
+                >
+                  <a className="block">{languageLinks[locale]?.name}</a>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </nav>
   );
 }

--- a/next/components/locale-switcher.tsx
+++ b/next/components/locale-switcher.tsx
@@ -22,7 +22,7 @@ export default function LocaleSwitcher() {
 
   useEffect(() => {
     setLanguages(locales.filter((locale) => locale != language));
-  }, [language]);
+  }, [language, locales]);
 
   return (
     <nav>


### PR DESCRIPTION
When I tried to run `lando npm run build`, while on the main branch,  the command failed with: 

```

Failed to compile.

./components/locale-switcher.tsx
13:19  Error: Insert `;`  prettier/prettier
14:4  Error: Insert `;`  prettier/prettier
19:24  Error: Insert `;`  prettier/prettier
21:4  Error: Insert `;`  prettier/prettier
24:32  Error: Replace `(locale·=>·locale·!=·language))` with `((locale)·=>·locale·!=·language));`  prettier/prettier
25:6  Warning: React Hook useEffect has a missing dependency: 'locales'. Either include it or remove the dependency array.  react-hooks/exhaustive-deps
25:17  Error: Replace `⏎` with `;`  prettier/prettier
35:72  Error: Insert `}·pr-3`}>`  prettier/prettier
36:11  Error: Replace `}·pr-3`}>{languageLinks[language]?.name}` with `{languageLinks[language]?.name}{"·"}⏎·······`  prettier/prettier
38:18  Error: Replace `<svg·xmlns="http://www.w3.org/2000/svg"·fill="none"·viewBox="0·0·24·24"·strokeWidth="1.5"·stroke="currentColor"·className="w-6·h-6"` with `(⏎··········<svg⏎············xmlns="http://www.w3.org/2000/svg"⏎············fill="none"⏎············viewBox="0·0·24·24"⏎············strokeWidth="1.5"⏎············stroke="currentColor"⏎············className="w-6·h-6"⏎··········`  prettier/prettier
39:1  Error: Replace `··········<path·strokeLinecap="round"·strokeLinejoin="round"·d="M4.5·15.75l7.5-7.5·7.5·7.5"` with `············<path⏎··············strokeLinecap="round"⏎··············strokeLinejoin="round"⏎··············d="M4.5·15.75l7.5-7.5·7.5·7.5"⏎···········`  prettier/prettier
40:1  Error: Replace `········</svg>` with `··········</svg>⏎········)`  prettier/prettier
41:19  Error: Replace `<svg·xmlns="http://www.w3.org/2000/svg"·fill="none"·viewBox="0·0·24·24"·strokeWidth="1.5"·stroke="currentColor"·className="w-6·h-6"` with `(⏎··········<svg⏎············xmlns="http://www.w3.org/2000/svg"⏎············fill="none"⏎············viewBox="0·0·24·24"⏎············strokeWidth="1.5"⏎············stroke="currentColor"⏎············className="w-6·h-6"⏎··········`  prettier/prettier
42:1  Error: Replace `··········<path·strokeLinecap="round"·strokeLinejoin="round"·d="M19.5·8.25l-7.5·7.5-7.5-7.5"` with `············<path⏎··············strokeLinecap="round"⏎··············strokeLinejoin="round"⏎··············d="M19.5·8.25l-7.5·7.5-7.5-7.5"⏎···········`  prettier/prettier
43:9  Error: Replace `</svg>` with `··</svg>⏎········)`  prettier/prettier
45:16  Error: Insert `(⏎········`  prettier/prettier
46:9  Error: Replace `{languages.map(locale` with `··{languages.map((locale)`  prettier/prettier
47:11  Error: Insert `··`  prettier/prettier
48:13  Error: Insert `··`  prettier/prettier
49:1  Error: Insert `··`  prettier/prettier
50:1  Error: Replace `··············` with `················`  prettier/prettier
51:1  Error: Insert `··`  prettier/prettier
52:13  Error: Insert `··`  prettier/prettier
53:1  Error: Insert `··`  prettier/prettier
54:17  Error: Insert `··`  prettier/prettier
55:17  Error: Insert `··`  prettier/prettier
56:1  Error: Insert `··`  prettier/prettier
57:17  Error: Insert `··`  prettier/prettier
58:1  Error: Insert `··`  prettier/prettier
59:15  Error: Insert `··`  prettier/prettier
60:1  Error: Replace `················` with `··················`  prettier/prettier
61:15  Error: Insert `··`  prettier/prettier
62:13  Error: Insert `··`  prettier/prettier
63:1  Error: Replace `··········` with `············`  prettier/prettier
64:1  Error: Insert `··`  prettier/prettier
65:7  Error: Replace `</ul>` with `··</ul>⏎······)`  prettier/prettier

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
info  - Linting and checking validity of types .%    
```

There are two issues: 

1. our setup requires prettier to be used (https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode ) I have set it up so that it automatically reformats the files on save, it saves a lot of time.
2. eslint complains about a missing dependency in useEffect: 
![image](https://user-images.githubusercontent.com/185412/213224422-08f63b78-b498-48e0-b4ac-fa067fae8c00.png)

So I have fixed the eslint error, and saved the file with prettier.

now the build goes through.
