### PR TITLE
Add back a patch for the jsonapi_menu_items module that adds the langcode

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -117,6 +117,9 @@
             "drupal/decoupled_router": {
                 "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-12-01/decouple_router-3111456-resolve-language-issue-58--get-translation.patch"
             },
+            "drupal/jsonapi_menu_items": {
+                "Add info about the langcode for menu items (issue #3192576)": "https://www.drupal.org/files/issues/2023-02-09/3192576-17_0.patch"
+            },
             "drupal/core": {
                 "Add support for the experimental recipes functionality": "https://git.drupalcode.org/project/distributions_recipes/-/raw/patch/recipe.patch",
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch",


### PR DESCRIPTION
I have added a new version of the patch on d.org: https://www.drupal.org/project/jsonapi_menu_items/issues/3192576#comment-14914978

This should add back the langcode when getting menu items from jsonapi.

To test

1. delete the web/modules/custom folder
2. run `lando composer install` so the patch is applied
3. test the response of menus