### PR TITLE
NEX-39: Add frontpage handling

### DIFF
--- a/drupal/recipes/wunder_landing_pages/README.md
+++ b/drupal/recipes/wunder_landing_pages/README.md
@@ -5,8 +5,11 @@ When installed, this recipe will create:
 * a "landing page" content type with:
   * field definitions
   * pathauto settings
-  * text paragraph
-  * image paragraph
+  * paragraphs
+* a "frontpage" content type with:
+  * field definitions
+  * pathauto settings
+  * paragraphs
 
 ### Manual Installation instructions
 

--- a/drupal/recipes/wunder_landing_pages/config/core.base_field_override.node.frontpage.promote.yml
+++ b/drupal/recipes/wunder_landing_pages/config/core.base_field_override.node.frontpage.promote.yml
@@ -1,0 +1,22 @@
+uuid: 0cfed645-1ed6-4dca-9fea-faf7b0096c58
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.frontpage
+id: node.frontpage.promote
+field_name: promote
+entity_type: node
+bundle: frontpage
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/drupal/recipes/wunder_landing_pages/config/core.entity_form_display.node.frontpage.default.yml
+++ b/drupal/recipes/wunder_landing_pages/config/core.entity_form_display.node.frontpage.default.yml
@@ -1,0 +1,91 @@
+uuid: 46c6fd5f-4687-4299-b175-6001374ef3bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.frontpage.field_content_elements
+    - node.type.frontpage
+  module:
+    - paragraphs
+    - path
+id: node.frontpage.default
+targetEntityType: node
+bundle: frontpage
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_content_elements:
+    type: paragraphs
+    weight: 8
+    region: content
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: _none
+      features:
+        add_above: '0'
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 2
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  promote: true
+  sticky: true

--- a/drupal/recipes/wunder_landing_pages/config/core.entity_view_display.node.frontpage.default.yml
+++ b/drupal/recipes/wunder_landing_pages/config/core.entity_view_display.node.frontpage.default.yml
@@ -1,0 +1,31 @@
+uuid: c510e2ec-8cc1-4cad-9c77-8fba67f9237c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.frontpage.field_content_elements
+    - node.type.frontpage
+  module:
+    - entity_reference_revisions
+    - user
+id: node.frontpage.default
+targetEntityType: node
+bundle: frontpage
+mode: default
+content:
+  field_content_elements:
+    type: entity_reference_revisions_entity_view
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/drupal/recipes/wunder_landing_pages/config/core.entity_view_display.node.frontpage.teaser.yml
+++ b/drupal/recipes/wunder_landing_pages/config/core.entity_view_display.node.frontpage.teaser.yml
@@ -1,0 +1,23 @@
+uuid: a28941d4-8f1a-4082-818d-92506db4a3ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.frontpage.field_content_elements
+    - node.type.frontpage
+  module:
+    - user
+id: node.frontpage.teaser
+targetEntityType: node
+bundle: frontpage
+mode: teaser
+content:
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_content_elements: true
+  langcode: true

--- a/drupal/recipes/wunder_landing_pages/config/field.field.node.frontpage.field_content_elements.yml
+++ b/drupal/recipes/wunder_landing_pages/config/field.field.node.frontpage.field_content_elements.yml
@@ -1,0 +1,38 @@
+uuid: 9ed8528b-05ac-4aa5-8a4a-48624ea856b7
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_elements
+    - node.type.frontpage
+  module:
+    - entity_reference_revisions
+id: node.frontpage.field_content_elements
+field_name: field_content_elements
+entity_type: node
+bundle: frontpage
+label: 'Content elements'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles: null
+    negate: 0
+    target_bundles_drag_drop:
+      formatted_text:
+        weight: 5
+        enabled: false
+      image:
+        weight: 6
+        enabled: false
+      links:
+        weight: 7
+        enabled: false
+      video:
+        weight: 8
+        enabled: false
+field_type: entity_reference_revisions

--- a/drupal/recipes/wunder_landing_pages/config/language.content_settings.node.frontpage.yml
+++ b/drupal/recipes/wunder_landing_pages/config/language.content_settings.node.frontpage.yml
@@ -1,0 +1,16 @@
+uuid: 36ab812e-5d33-48b1-beb6-2179eaba8923
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.frontpage
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.frontpage
+target_entity_type_id: node
+target_bundle: frontpage
+default_langcode: site_default
+language_alterable: true

--- a/drupal/recipes/wunder_landing_pages/config/node.type.frontpage.yml
+++ b/drupal/recipes/wunder_landing_pages/config/node.type.frontpage.yml
@@ -1,0 +1,17 @@
+uuid: 49a18379-7818-4fa6-b340-567777a70405
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Frontpage
+type: frontpage
+description: 'Represents the frontpage of the site. Only one content of this type can be created.'
+help: ''
+new_revision: true
+preview_mode: 0
+display_submitted: false

--- a/drupal/recipes/wunder_landing_pages/config/pathauto.pattern.frontpage.yml
+++ b/drupal/recipes/wunder_landing_pages/config/pathauto.pattern.frontpage.yml
@@ -1,0 +1,22 @@
+uuid: 42918896-bedc-43ca-84a9-4af202957cc1
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: frontpage
+label: frontpage
+type: 'canonical_entities:node'
+pattern: '/frontpage-[language:langcode]'
+selection_criteria:
+  9b7d0d83-0421-493f-ab79-80d62a55ea7f:
+    id: 'entity_bundle:node'
+    negate: false
+    uuid: 9b7d0d83-0421-493f-ab79-80d62a55ea7f
+    context_mapping:
+      node: node
+    bundles:
+      frontpage: frontpage
+selection_logic: and
+weight: -5
+relationships: {  }

--- a/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.frontpage.yml
+++ b/drupal/recipes/wunder_next_setup/config/next.next_entity_type_config.node.frontpage.yml
@@ -1,0 +1,13 @@
+uuid: 8772fee2-6539-43ad-bfbe-0932ee183285
+langcode: en
+status: true
+dependencies: {  }
+id: node.frontpage
+site_resolver: site_selector
+configuration:
+  sites:
+    frontend: frontend
+revalidator: path
+revalidator_configuration:
+  revalidate_page: true
+  additional_paths: "/\r\n/fi\r\n/en\r\n/sv"

--- a/drupal/web/modules/custom/wunder_next/src/Plugin/Validation/Constraint/UniqueFrontpage.php
+++ b/drupal/web/modules/custom/wunder_next/src/Plugin/Validation/Constraint/UniqueFrontpage.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\wunder_next\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that frontpage translations are unique.
+ *
+ * @Constraint(
+ *   id = "UniqueFrontpage",
+ *   label = @Translation("Unique Frontpage", context = "Validation"),
+ *   type = "string"
+ * )
+ */
+class UniqueFrontpage extends Constraint {}

--- a/drupal/web/modules/custom/wunder_next/src/Plugin/Validation/Constraint/UniqueFrontpageValidator.php
+++ b/drupal/web/modules/custom/wunder_next/src/Plugin/Validation/Constraint/UniqueFrontpageValidator.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\wunder_next\Plugin\Validation\Constraint;
+
+use Drupal\node\Entity\Node;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the UniqueFrontpage constraint.
+ */
+class UniqueFrontpageValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($node, Constraint $constraint) {
+    /** @var \Drupal\node\Entity\Node $node */
+    if ($node->bundle() === 'frontpage') {
+      $existing_translation = $this->findFrontpageTranslation($node);
+
+      // If we find an existing translation, raise a violation.
+      if ($existing_translation !== FALSE) {
+        $violation = t(
+          'A frontpage already exists for the language (@language). <a href="@url">Edit the existing frontpage</a>',
+          [
+            '@language' => $node->language()->getName(),
+            '@url' => $existing_translation->toUrl()->toString(),
+          ]
+        );
+
+        $this->context->addViolation($violation);
+      }
+    }
+  }
+
+  /**
+   * Find existing frontpage translation.
+   *
+   * @param \Drupal\node\Entity\Node $node
+   *   The current node being validate.
+   *
+   * @return mixed
+   *   An entity if found || FALSE
+   */
+  private function findFrontpageTranslation(Node $node) {
+    $langcode = $node->language()->getId();
+
+    // Get all frontpage entities that has the current entity's translation.
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+    $entities = $storage->loadByProperties(
+      [
+        'langcode' => $langcode,
+        'type' => 'frontpage',
+      ]
+    );
+
+    foreach ($entities as $entity) {
+      if ($entity->id() != $node->id()) {
+        // Return the existing node if we find one.
+        return $entity;
+      }
+    }
+
+    return FALSE;
+  }
+
+}

--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -27,3 +27,12 @@ function wunder_next_next_site_load($entities) {
     }
   }
 }
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function wunder_next_entity_type_alter(array &$entity_types) {
+  // Add our custom validation constraint that makes sure
+  // that there is only one frontpage node per translation:
+  $entity_types['node']->addConstraint('UniqueFrontpage');
+}

--- a/drupal/web/modules/custom/wunder_search/src/Plugin/Normalizer/NodeNormalizer.php
+++ b/drupal/web/modules/custom/wunder_search/src/Plugin/Normalizer/NodeNormalizer.php
@@ -123,6 +123,11 @@ class NodeNormalizer extends ContentEntityNormalizer {
    * {@inheritdoc}
    */
   public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+    // It's not required to go through all the normalisation when deleting:
+    if (!empty($context) && isset($context['method']) && $context['method'] == 'delete') {
+      return [];
+    }
+
     $data = [
       'id' => $object->id(),
       'uuid' => $object->uuid(),

--- a/next/components/node--frontpage.tsx
+++ b/next/components/node--frontpage.tsx
@@ -1,0 +1,16 @@
+import { DrupalNode } from "next-drupal";
+
+import { Paragraph } from "@/components/paragraph";
+
+interface NodeFrontPage {
+  node: DrupalNode;
+  viewMode?: string;
+}
+
+export function NodeFrontpage({ node }: NodeFrontPage) {
+  if (!node.field_content_elements.length) return null;
+
+  return node.field_content_elements.map((paragraph) => {
+    return <Paragraph key={paragraph.id} paragraph={paragraph} />;
+  });
+}

--- a/next/lib/get-params.ts
+++ b/next/lib/get-params.ts
@@ -21,6 +21,19 @@ export function getNodePageJsonApiParams(resourceType: string) {
       ]);
   }
 
+  // The frontpage content type has paragraphs, stored in the "field_content_elements" field:
+  if (resourceType === "node--frontpage") {
+    apiParams
+      .addInclude([
+        "field_content_elements",
+        "field_content_elements.field_image.field_media_image",
+        "field_content_elements.field_video",
+      ])
+      // Only published frontpages:
+      .addFilter("status", "1")
+      .addFields("node--frontpage", ["title", "field_content_elements"]);
+  }
+
   // The article content type has an image field, and author information:
   if (resourceType === "node--article") {
     apiParams.addInclude(["field_image", "uid"]);

--- a/next/pages/[...slug].tsx
+++ b/next/pages/[...slug].tsx
@@ -81,6 +81,18 @@ export async function getStaticProps(
 
   const type = path.jsonapi.resourceName;
 
+  // If we are looking at the path of a frontpage node,
+  // redirect the user to the homepage for that language:
+
+  if (type === "node--frontpage") {
+    return {
+      redirect: {
+        destination: "/" + context.locale,
+        permanent: false,
+      },
+    };
+  }
+
   const resource = await drupal.getResourceFromContext<DrupalNode>(
     path,
     context,


### PR DESCRIPTION
This branch adds the possibility for the content editor to decide what is displayed on the frontpage of the site for each of the translations.

### How it works

In the backend: 
* there is now a new content type called "frontpage". Paragraphs can be added to the frontpage and it can be translated
* there is a constraint that prevents editors to add more than one frontpage translation per language
* the path of the frontpage is set via pathauto
* the frontend node is not indexed in elasticsearch (this PR also fixes an issue where items could not be deleted from elasticsearch)

On the frontend:
* the `index.tsx` contains a query to get the frontpage for the language. if found, its contents (paragraphs) are rendered at the top of the page, before the fixed listing that shows the latest articles.
* because the frontpage also has its own url in drupal (something like /en/frontpage-en for english for example), the [...slug.tsx] page now contains code that will issue a redirect to the root of the site if the path corresponds to a frontpage node. This way we are able to preview the frontpage when visiting the "view" tab for the frontpage node.

### How to test

* run the usual big command:  `lando composer install && lando generate-oauth-keys && lando drush si --site-name="My great site name here" -y && lando install-recipe wunder_next_setup && lando drush wunder_next:setup-user-and-consumer && lando drush eshd -y && lando drush eshs` and then copy the usual credentials to `.env.local` 
* create a frontpage node for english
* translate into finnish
* translate info swedish
* try to add a new frontpage node -> you will see a message warning you that it already exists
* on the content list, click on the frontpage node you created in all languages, check that the contents are displayed in the preview
* visit the frontend site and see your contents displayed 

### Screenshots

Creating a frontpage: 
![image](https://user-images.githubusercontent.com/185412/218478893-758961a2-8d17-4bca-b9e9-132ca9a13839.png)




Trying to add a second frontpage for a language: 
![image](https://user-images.githubusercontent.com/185412/218479410-405290a3-e962-41a0-987f-97c571204ccd.png)




Viewing the preview of the frontpage, where the iframe has been redirected to /en
![image](https://user-images.githubusercontent.com/185412/218480445-41cdcc60-ba04-4cc3-afa5-e54435e9c7b2.png)





