### PR TITLE
Downgrade zod to fix performance issues

### DIFF
--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -26,7 +26,7 @@
         "react-i18next": "^12.1.5",
         "react-youtube": "^10.1.0",
         "sharp": "^0.31.3",
-        "zod": "^3.20.6"
+        "zod": "^3.19.1"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^13.1.6",
@@ -17459,9 +17459,9 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/zod": {
-      "version": "3.20.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
-      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -30059,9 +30059,9 @@
       }
     },
     "zod": {
-      "version": "3.20.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
-      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA=="
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
+      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA=="
     }
   }
 }

--- a/next/package.json
+++ b/next/package.json
@@ -31,7 +31,7 @@
     "react-i18next": "^12.1.5",
     "react-youtube": "^10.1.0",
     "sharp": "^0.31.3",
-    "zod": "^3.20.6"
+    "zod": "^3.19.1"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^13.1.6",


### PR DESCRIPTION
See https://stackoverflow.com/questions/74881472/slow-typescript-autocompletion-in-vs-code-for-zod
When this is released, it might fix it and we can upgrade again: https://github.com/colinhacks/zod/pull/2107