### PR TITLE
Show excerpt on article pages

### DIFF
--- a/next/components/article.tsx
+++ b/next/components/article.tsx
@@ -15,6 +15,9 @@ export function Article({ article, ...props }: ArticleProps) {
   return (
     <article {...props}>
       <HeadingPage>{article.title}</HeadingPage>
+      {article.field_excerpt && (
+        <div className="my-4 text-xl">{article.field_excerpt}</div>
+      )}
       <div className="mb-4 text-gray-600">
         {article.uid?.display_name && (
           <span>

--- a/next/lib/get-node-page-json-api-params.ts
+++ b/next/lib/get-node-page-json-api-params.ts
@@ -52,6 +52,7 @@ export function getNodePageJsonApiParams(resourceType: ResourceType) {
       "field_image",
       "status",
       "metatag",
+      "field_excerpt",
     ]);
   }
 

--- a/next/lib/zod/article-teaser.ts
+++ b/next/lib/zod/article-teaser.ts
@@ -1,18 +1,9 @@
 import { DrupalNode } from "next-drupal";
 import { z } from "zod";
 
-import { ImageShape } from "@/lib/zod/paragraph";
+import { ArticleBaseSchema } from "@/lib/zod/article";
 
-export const ArticleTeaserSchema = z.object({
-  type: z.literal("node--article"),
-  id: z.string(),
-  title: z.string(),
-  created: z.string(),
-  uid: z.object({
-    id: z.string(),
-    display_name: z.string(),
-  }),
-  field_image: ImageShape,
+export const ArticleTeaserSchema = ArticleBaseSchema.extend({
   path: z.object({
     alias: z.string(),
   }),

--- a/next/lib/zod/article.ts
+++ b/next/lib/zod/article.ts
@@ -4,20 +4,23 @@ import { z } from "zod";
 import { MetatagsSchema } from "@/lib/zod/metatag";
 import { ImageShape } from "@/lib/zod/paragraph";
 
-export const ArticleSchema = z.object({
+export const ArticleBaseSchema = z.object({
   type: z.literal("node--article"),
   id: z.string(),
-  title: z.string(),
   created: z.string(),
-  body: z.object({
-    processed: z.string(),
-  }),
   uid: z.object({
     id: z.string(),
     display_name: z.string(),
   }),
+  title: z.string(),
   field_image: ImageShape,
+});
+
+const ArticleSchema = ArticleBaseSchema.extend({
   metatag: MetatagsSchema.optional(),
+  body: z.object({
+    processed: z.string(),
+  }),
 });
 
 export function validateAndCleanupArticle(article: DrupalNode): Article | null {

--- a/next/lib/zod/article.ts
+++ b/next/lib/zod/article.ts
@@ -18,6 +18,7 @@ export const ArticleBaseSchema = z.object({
 
 const ArticleSchema = ArticleBaseSchema.extend({
   metatag: MetatagsSchema.optional(),
+  field_excerpt: z.string().optional(),
   body: z.object({
     processed: z.string(),
   }),


### PR DESCRIPTION
This PR shows field_excerpt on article pages. It does NOT add it to the article "teaser" list on the frontpage.

![CleanShot 2023-03-02 at 11 30 38@2x](https://user-images.githubusercontent.com/22575651/222388748-dcd57651-b71a-4e17-80a7-fe2225eea6cb.png)

To test, run the usual `lando npm run dev` and navigate to an article page - you should see the excerpt if available.