### PR TITLE
NEX-47: Style links paragraph

### DIFF
--- a/next/components/paragraph--links.tsx
+++ b/next/components/paragraph--links.tsx
@@ -1,19 +1,23 @@
 import Link from "next/link";
 
 import { Links } from "@/lib/zod/paragraph";
+import ArrowIcon from "@/styles/icons/arrow.svg";
 
 export function ParagraphLinks({ paragraph }: { paragraph: Links }) {
+  if (!paragraph.field_links?.length) return null;
+
   return (
-    <ul className="list-disc p-2">
+    <ul className="my-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
       {paragraph.field_links.map((link, index) => (
-        <li key={index}>
-          <Link
-            className="text-md text-wunderpurple-600 hover:underline"
-            href={link.full_url}
-          >
-            {link.title}
-          </Link>
-        </li>
+        <Link
+          key={index}
+          role="listitem"
+          href={link.full_url}
+          className="relative min-h-[6em] cursor-pointer rounded bg-wunderpurple-100 p-8 text-lg text-wunderpurple-600 shadow hover:bg-wunderpurple-200"
+        >
+          {link.title}
+          <ArrowIcon aria-hidden className="absolute top-1/4 right-2 h-6 w-6" />
+        </Link>
       ))}
     </ul>
   );


### PR DESCRIPTION
Implements https://wunder.atlassian.net/browse/NEX-47

This PR adds some basic styling to the links paragraphs so they're a bit more useful as an example. There wasn't anything similar in the component library, so I made something up. I probably won't win any design awards anytime soon :) 

<img width="501" alt="CleanShot 2023-03-02 at 15 54 32@2x" src="https://user-images.githubusercontent.com/22575651/222448633-8c155377-93f3-4ad2-a0f0-2e3072c16420.png">
<img width="1196" alt="CleanShot 2023-03-02 at 15 55 25@2x" src="https://user-images.githubusercontent.com/22575651/222448643-e0230854-0585-4e1b-9176-07178324c814.png">
