### PR TITLE
NEX-11: Override the secret set in the consumer entity on the fly using an environment variable

### DIFF
--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -30,6 +30,34 @@ function wunder_next_next_site_load($entities) {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_load().
+ */
+function wunder_next_consumer_load($entities) {
+  // We want to be able to vary the secret of the consumer
+  // entity based on our environment variable.
+  // Get the settings for the module, that are set to
+  // the corresponding environment variables in settings.php:
+  $settings = Settings::get('wunder_next.settings');
+
+  // The secret is set on the consumer entity as a
+  // password field, so we get the password service
+  // in order to hash it:
+  /** @var \Drupal\Core\Password\PhpassHashedPassword $password_service */
+  $password_service = \Drupal::service('password');
+
+  /** @var \Drupal\consumers\Entity\ConsumerInterface $consumer */
+  foreach ($entities as $consumer) {
+    // Identify the consumer with the right client id.
+    if ($consumer->getClientId() == $settings['client_id']) {
+      // We set the consumer secret "on the fly" to the hashed
+      // value of our setting, which is turn is determined
+      // by the environment variable.
+      $consumer->set('secret', $password_service->hash($settings['client_secret']));
+    }
+  }
+}
+
+/**
  * Implements hook_entity_type_alter().
  */
 function wunder_next_entity_type_alter(array &$entity_types) {

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -45,9 +45,11 @@ $settings['file_scan_ignore_directories'] = [
   'bower_components',
 ];
 
-// Get the url of the frontend from an environment variable:
+// Get environment variables into settings:
 $settings['wunder_next.settings']['frontend_url'] = $_ENV['WUNDER_NEXT_FRONTEND_URL'];
 $settings['wunder_next.settings']['revalidate_secret'] = $_ENV['DRUPAL_REVALIDATE_SECRET'];
+$settings['wunder_next.settings']['client_secret'] = $_ENV['DRUPAL_CLIENT_SECRET'];
+$settings['wunder_next.settings']['client_id'] = $_ENV['DRUPAL_CLIENT_ID'];
 
 // Environment-specific settings.
 $env = $_ENV['ENVIRONMENT_NAME'];


### PR DESCRIPTION
This PR adds a `hook_entity_type_load` hook implementation that will replace the hashed secret set in the consumer entity on the fly, using the value of an environment variable.

This should allow us to make the site behave correctly in different hosted settings, like in a branch envronment in silta.