### PR TITLE
NEX-46: Dynamically import Accordion and Video paragraphs

### DIFF
--- a/next/components/paragraph.tsx
+++ b/next/components/paragraph.tsx
@@ -1,10 +1,18 @@
+import dynamic from "next/dynamic";
+
 import { ParagraphImage } from "@/components/paragraph--image";
 import { ParagraphLinks } from "@/components/paragraph--links";
 import { ParagraphText } from "@/components/paragraph--text";
-import { ParagraphVideo } from "@/components/paragraph--video";
 import { Paragraph } from "@/lib/zod/paragraph";
 
-import { ParagraphAccordion } from "./paragraph--accordion";
+// Use dynamic imports to defer loading a component until after initial page load: https://nextjs.org/docs/advanced-features/dynamic-import
+const ParagraphVideo = dynamic(() =>
+  import("./paragraph--video").then((mod) => mod.ParagraphVideo)
+);
+
+const ParagraphAccordion = dynamic(() =>
+  import("./paragraph--accordion").then((mod) => mod.ParagraphAccordion)
+);
 
 export function Paragraph({ paragraph }: { paragraph: Paragraph }) {
   if (!paragraph) {
@@ -12,16 +20,21 @@ export function Paragraph({ paragraph }: { paragraph: Paragraph }) {
   }
 
   switch (paragraph.type) {
-    case "paragraph--formatted_text":
+    case "paragraph--formatted_text": {
       return <ParagraphText paragraph={paragraph} />;
-    case "paragraph--image":
-      return <ParagraphImage paragraph={paragraph} />;
-    case "paragraph--video":
-      return <ParagraphVideo paragraph={paragraph} />;
-    case "paragraph--links":
+    }
+    case "paragraph--links": {
       return <ParagraphLinks paragraph={paragraph} />;
-    case "paragraph--accordion":
+    }
+    case "paragraph--image": {
+      return <ParagraphImage paragraph={paragraph} />;
+    }
+    case "paragraph--video": {
+      return <ParagraphVideo paragraph={paragraph} />;
+    }
+    case "paragraph--accordion": {
       return <ParagraphAccordion paragraph={paragraph} />;
+    }
     default:
       return null;
   }


### PR DESCRIPTION
https://wunder.atlassian.net/browse/NEX-46

This PR adds and example of using [Next.js Dynamic Imports](https://nextjs.org/docs/advanced-features/dynamic-import) to defer loading of the ParagraphAccordion and ParagraphVideo components until they're needed. It does seem to to have a (modest) effect - the "First load JS" on the homepage is 6kB less on the homepage where neither component is used. For this template, though, it's more about introducing the pattern, so developers are aware that this is the way to prevent the Paragraph component growing over time.

`next build` before and after:

![pic](https://user-images.githubusercontent.com/22575651/227522893-5b44311b-8422-482f-9b44-faa558c65a0b.png)
