### PR TITLE
Silta: install the site at each deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,13 +67,15 @@ workflows:
                 name: Install drupal from scratch
                 command: |
                   pwd
+                  cd web
                   drush si minimal -y
                   // Install recipe
                   drush wunder_next:setup-user-and-consumer
                   drush eshd -y
                   drush eshs
                   drush en wunder_democontent -y
-                  cd /app/drupal/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
+                  core/scripts/drupal recipe ../recipes/wunder_next_setup
+                  cd /home/circleci/project/drupal/web
                   drush mim --group=demo_content --execute-dependencies
                   drush cr
           context: silta_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ workflows:
                   fi
                   next_domain=${release_name}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   next_public_base_url=https://${next_domain}
-                  drupal_client_secret=drupal_client_secret_not_secure_used_only_locally=
+                  drupal_client_secret=drupal_client_secret_not_secure_used_only_locally
                   drupal_client_id=drupal-client-id
                   echo "export NEXT_PUBLIC_DRUPAL_BASE_URL=${next_public_base_url}" >> "$BASH_ENV"
                   echo "export NEXT_IMAGE_DOMAIN=${next_domain}" >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ workflows:
                   fi
                   next_domain=${release_name}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   next_public_base_url=https://${next_domain}
-                  drupal_client_secret=XmLM28mPZSq4e6boUcyP2raYvlY=
+                  drupal_client_secret=drupal_client_secret_not_secure_used_only_locally=
                   drupal_client_id=drupal-client-id
                   echo "export NEXT_PUBLIC_DRUPAL_BASE_URL=${next_public_base_url}" >> "$BASH_ENV"
                   echo "export NEXT_IMAGE_DOMAIN=${next_domain}" >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ workflows:
                   next_domain=${release_name}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   next_public_base_url=https://${next_domain}
                   drupal_client_secret=XmLM28mPZSq4e6boUcyP2raYvlY=
-                  drupal_client_id=next-drupal-consumer
+                  drupal_client_id=drupal-client-id
                   echo "export NEXT_PUBLIC_DRUPAL_BASE_URL=${next_public_base_url}" >> "$BASH_ENV"
                   echo "export NEXT_IMAGE_DOMAIN=${next_domain}" >> "$BASH_ENV"
                   echo "export DRUPAL_CLIENT_SECRET=${drupal_client_secret}" >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,21 +63,6 @@ workflows:
                   chmod 600 oauth/private.key oauth/public.key
             - silta/drupal-composer-install
             - silta/npm-install-build
-            - run:
-                name: Install drupal from scratch
-                command: |
-                  pwd
-                  cd web
-                  drush si minimal -y
-                  // Install recipe
-                  drush wunder_next:setup-user-and-consumer
-                  drush eshd -y
-                  drush eshs
-                  drush en wunder_democontent -y
-                  core/scripts/drupal recipe ../recipes/wunder_next_setup
-                  cd /home/circleci/project/drupal/web
-                  drush mim --group=demo_content --execute-dependencies
-                  drush cr
           context: silta_dev
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,19 @@ workflows:
                   chmod 600 oauth/private.key oauth/public.key
             - silta/drupal-composer-install
             - silta/npm-install-build
+            - run:
+                name: Install drupal from scratch
+                command: |
+                  pwd
+                  drush si minimal -y
+                  // Install recipe
+                  drush wunder_next:setup-user-and-consumer
+                  drush eshd -y
+                  drush eshs
+                  drush en wunder_democontent -y
+                  cd /app/drupal/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
+                  drush mim --group=demo_content --execute-dependencies
+                  drush cr
           context: silta_dev
           filters:
             branches:

--- a/silta/silta-next.yml
+++ b/silta/silta-next.yml
@@ -12,4 +12,4 @@ services:
       NEXT_PUBLIC_DRUPAL_BASE_URL: <|next_public_base_url|>
       NEXT_IMAGE_DOMAIN: <|next_image_domain|>
       DRUPAL_CLIENT_SECRET: <|drupal_client_secret|>
-      DRUPAL_CLIENT_ID: next-drupal-consumer
+      DRUPAL_CLIENT_ID: drupal-client-id

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -10,7 +10,7 @@ php:
     WUNDER_NEXT_FRONTEND_URL: https://<|next_domain|>
     DRUPAL_REVALIDATE_SECRET: revalidate_secret_not_secure_used_only_locally
     DRUPAL_CLIENT_SECRET: drupal_client_secret_not_secure_used_only_locally
-    DRUPAL_CLIENT_ID: drupal-client-id4
+    DRUPAL_CLIENT_ID: drupal-client-id
   hashsalt: notsosecurehashnotsosecurehashnotsosecurehash
   postupgrade:
     afterCommand: |
@@ -22,7 +22,7 @@ php:
       drush cr
       drush eshd -y
       drush eshs
-      drush mim --group=demo_content --execute-dependencies
+      drush mim --group=demo_content --execute-dependencies --skip-progress-bar
 
 # Configure reference data that will be used when creating new environments.
 referenceData:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -12,6 +12,9 @@ php:
     DRUPAL_CLIENT_SECRET: drupal_client_secret_not_secure_used_only_locally
     DRUPAL_CLIENT_ID: drupal-client-id
   hashsalt: notsosecurehashnotsosecurehashnotsosecurehash
+  # This section is used in the template only, it will reinstall the site and apply
+  # all standard configuration at each commit. When creating a new project from this template
+  # you have to remove this section.
   postupgrade:
     afterCommand: |
       drush si minimal -y

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -9,6 +9,8 @@ php:
   env:
     WUNDER_NEXT_FRONTEND_URL: https://<|next_domain|>
     DRUPAL_REVALIDATE_SECRET: revalidate_secret_not_secure_used_only_locally
+    DRUPAL_CLIENT_SECRET: drupal_client_secret_not_secure_used_only_locally
+    DRUPAL_CLIENT_ID: drupal-client-id
   hashsalt: notsosecurehashnotsosecurehashnotsosecurehash
 
 # Configure reference data that will be used when creating new environments.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -16,12 +16,12 @@ php:
     afterCommand: |
       drush si minimal -y
       drush wunder_next:setup-user-and-consumer
+      drush en wunder_democontent -y
+      cd /app/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
+      drush cr
       drush eshd -y
       drush eshs
-      drush en wunder_democontent -y
-      core/scripts/drupal recipe ../recipes/wunder_next_setup
       drush mim --group=demo_content --execute-dependencies
-      drush cr
 
 # Configure reference data that will be used when creating new environments.
 referenceData:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -12,6 +12,16 @@ php:
     DRUPAL_CLIENT_SECRET: drupal_client_secret_not_secure_used_only_locally
     DRUPAL_CLIENT_ID: drupal-client-id
   hashsalt: notsosecurehashnotsosecurehashnotsosecurehash
+  postupgrade:
+    afterCommand: |
+      drush si minimal -y
+      drush wunder_next:setup-user-and-consumer
+      drush eshd -y
+      drush eshs
+      drush en wunder_democontent -y
+      core/scripts/drupal recipe ../recipes/wunder_next_setup
+      drush mim --group=demo_content --execute-dependencies
+      drush cr
 
 # Configure reference data that will be used when creating new environments.
 referenceData:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -15,6 +15,7 @@ php:
   postupgrade:
     afterCommand: |
       drush si minimal -y
+      chmod +x /app/web/core/scripts/drupal
       cd /app/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
       drush wunder_next:setup-user-and-consumer
       drush en wunder_democontent -y

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -10,14 +10,14 @@ php:
     WUNDER_NEXT_FRONTEND_URL: https://<|next_domain|>
     DRUPAL_REVALIDATE_SECRET: revalidate_secret_not_secure_used_only_locally
     DRUPAL_CLIENT_SECRET: drupal_client_secret_not_secure_used_only_locally
-    DRUPAL_CLIENT_ID: drupal-client-id
+    DRUPAL_CLIENT_ID: drupal-client-id4
   hashsalt: notsosecurehashnotsosecurehashnotsosecurehash
   postupgrade:
     afterCommand: |
       drush si minimal -y
+      cd /app/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
       drush wunder_next:setup-user-and-consumer
       drush en wunder_democontent -y
-      cd /app/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
       drush cr
       drush eshd -y
       drush eshs


### PR DESCRIPTION
Compared to the existing `siltatest` branch, this branch adds:

* postupgrade command that executes the same steps that we instruct users to run locally in lando
* added (hardcoded) env vars needed for the drush command that creates the consumer in drupal

## To note

1. when the migration creates the content, the backend site will try to contact the frontend site to invalidate the pages: this will result in errors, but they can be ignored
2. drupal's admin password shows up in the output in circleci, which is public for this project, maybe not great?

Other than those, I think this can serve the needs of the template, so we can be sure that the whole mechanism works at each commit.

