### PR TITLE
Replace release name logic with silta cli command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,15 +46,8 @@ workflows:
                 name: Set environment variables
                 command: |
                   cp -r ~/project/silta ~/project/drupal/
-                  # Make sure release name is lowercase without special characters.
-                  branchname_lower="${CIRCLE_BRANCH,,}"
-                  release_name="${branchname_lower//[^[:alnum:]]/-}"
-                  release_name=`echo $release_name | sed -e s/-next//`
-                  # If name is too long, truncate it and append a hash
-                  if [ ${#release_name} -ge 35 ]; then
-                    release_name="$(printf "$release_name" | cut -c 1-34)$(printf "$release_name" | shasum -a 256 | cut -c 1-3 )"
-                  fi
-                  next_domain=${release_name}-next.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
+                  release_name_next=`silta ci release name --release-suffix next`
+                  next_domain=${release_name_next}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   sed -i -e "s/<|next_domain|>/$next_domain/" silta/silta.yml
                   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out keypair.pem
                   openssl pkey -in keypair.pem -out oauth/private.key
@@ -112,17 +105,11 @@ workflows:
             - run:
                 name: Set environment variables 
                 command: |
-                  # Make sure release name is lowercase without special characters.
-                  branchname_lower="${CIRCLE_BRANCH,,}"
-                  release_name="${branchname_lower//[^[:alnum:]]/-}"
-                  release_name=`echo $release_name | sed -e s/-next//`
-                  # If name is too long, truncate it and append a hash
-                  if [ ${#release_name} -ge 35 ]; then
-                    release_name="$(printf "$release_name" | cut -c 1-34)$(printf "$release_name" | shasum -a 256 | cut -c 1-3 )"
-                  fi
+                  release_name=`silta ci release name`
+                  release_name_next=`silta ci release name --release-suffix next`
                   drupal_domain=${release_name}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   drupal_public_base_url=https://${drupal_domain}
-                  next_domain=${release_name}-next.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
+                  next_domain=${release_name_next}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   next_public_base_url=https://${next_domain}
                   drupal_client_secret=drupal_client_secret_not_secure_used_only_locally
                   drupal_client_id=drupal-client-id

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
                   
                   # If name is too long, truncate it and append a hash
                   if [ ${#release_name_next} -ge 35 ]; then
-                    release_name_next="$(printf "$release_name_next" | cut -c 1-34)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
+                    release_name_next="$(printf "$release_name_next" | cut -c 1-30)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
                   fi
                   next_domain=${release_name_next}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   sed -i -e "s/<|next_domain|>/$next_domain/" silta/silta.yml
@@ -115,11 +115,11 @@ workflows:
 
                   # If name is too long, truncate it and append a hash
                   if [ ${#release_name} -ge 35 ]; then
-                    release_name="$(printf "$release_name" | cut -c 1-34)$(printf "$release_name" | shasum -a 256 | cut -c 1-3 )"
+                    release_name="$(printf "$release_name" | cut -c 1-30)$(printf "$release_name" | shasum -a 256 | cut -c 1-3 )"
                   fi
                   # If name is too long, truncate it and append a hash
                   if [ ${#release_name_next} -ge 35 ]; then
-                    release_name_next="$(printf "$release_name_next" | cut -c 1-34)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
+                    release_name_next="$(printf "$release_name_next" | cut -c 1-30)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
                   fi
                   drupal_domain=${release_name}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   drupal_public_base_url=https://${drupal_domain}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,11 @@ workflows:
                 command: |
                   cp -r ~/project/silta ~/project/drupal/
                   release_name_next=`silta ci release name --release-suffix next`
+                  
+                  # If name is too long, truncate it and append a hash
+                  if [ ${#release_name_next} -ge 35 ]; then
+                    release_name_next="$(printf "$release_name_next" | cut -c 1-34)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
+                  fi
                   next_domain=${release_name_next}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   sed -i -e "s/<|next_domain|>/$next_domain/" silta/silta.yml
                   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out keypair.pem
@@ -107,6 +112,15 @@ workflows:
                 command: |
                   release_name=`silta ci release name`
                   release_name_next=`silta ci release name --release-suffix next`
+
+                  # If name is too long, truncate it and append a hash
+                  if [ ${#release_name} -ge 35 ]; then
+                    release_name="$(printf "$release_name" | cut -c 1-34)$(printf "$release_name" | shasum -a 256 | cut -c 1-3 )"
+                  fi
+                  # If name is too long, truncate it and append a hash
+                  if [ ${#release_name_next} -ge 35 ]; then
+                    release_name_next="$(printf "$release_name_next" | cut -c 1-34)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
+                  fi
                   drupal_domain=${release_name}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   drupal_public_base_url=https://${drupal_domain}
                   next_domain=${release_name_next}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
                   release_name_next=`silta ci release name --release-suffix next`
                   
                   # If name is too long, truncate it and append a hash
-                  if [ ${#release_name_next} -ge 35 ]; then
+                  if [ ${#release_name_next} -ge 33 ]; then
                     release_name_next="$(printf "$release_name_next" | cut -c 1-30)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
                   fi
                   next_domain=${release_name_next}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
@@ -114,11 +114,11 @@ workflows:
                   release_name_next=`silta ci release name --release-suffix next`
 
                   # If name is too long, truncate it and append a hash
-                  if [ ${#release_name} -ge 35 ]; then
+                  if [ ${#release_name} -ge 33 ]; then
                     release_name="$(printf "$release_name" | cut -c 1-30)$(printf "$release_name" | shasum -a 256 | cut -c 1-3 )"
                   fi
                   # If name is too long, truncate it and append a hash
-                  if [ ${#release_name_next} -ge 35 ]; then
+                  if [ ${#release_name_next} -ge 33 ]; then
                     release_name_next="$(printf "$release_name_next" | cut -c 1-30)$(printf "$release_name_next" | shasum -a 256 | cut -c 1-3 )"
                   fi
                   drupal_domain=${release_name}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN


### PR DESCRIPTION
*Changes proposed in this PR:*
- Use silta-cli release name command instead of custom logic to get the correct environment domains

*How to test:*
1. Check the site works

*Link to feature environment:*
Drupal: feature-support-long-branch-nacf7.next4drupal-project.dev.wdr.io
Frontend: feature-support-long-branch-na7b0.next4drupal-project.dev.wdr.io 

