### PR TITLE
NEX-61: Do not show preview buttons in content types edit form

### DIFF
--- a/drupal/recipes/wunder_base/config/node.type.article.yml
+++ b/drupal/recipes/wunder_base/config/node.type.article.yml
@@ -9,5 +9,5 @@ type: article
 description: 'Use <em>articles</em> for time-sensitive content like news, press releases or blog posts.'
 help: ''
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: true

--- a/drupal/recipes/wunder_pages/config/node.type.page.yml
+++ b/drupal/recipes/wunder_pages/config/node.type.page.yml
@@ -16,5 +16,5 @@ type: page
 description: 'Page content type. Contains paragraphs.'
 help: ''
 new_revision: true
-preview_mode: 1
+preview_mode: 0
 display_submitted: false


### PR DESCRIPTION
Jira: https://wunder.atlassian.net/browse/NEX-61

This PR hides the standard Drupal "preview" buttons in all existing content types, to prevent confusion with the next.js preview.
