### PR TITLE
feature/nex-11-adminpwd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ workflows:
                   fi
                   next_domain=${release_name_next}.$CIRCLE_PROJECT_REPONAME.$CLUSTER_DOMAIN
                   sed -i -e "s/<|next_domain|>/$next_domain/" silta/silta.yml
+                  sed -i -e "s/<|drupal_admin_pwd|>/$DRUPAL_ADMIN_PWD/" silta/silta.yml
                   openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:4096 -out keypair.pem
                   openssl pkey -in keypair.pem -out oauth/private.key
                   openssl pkey -in keypair.pem -pubout -out oauth/public.key

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -17,7 +17,7 @@ php:
   # you have to remove this section.
   postupgrade:
     afterCommand: |
-      drush si minimal -y
+      drush si minimal --account-pass=${DRUPAL_ADMIN_PWD} -y
       chmod +x /app/web/core/scripts/drupal
       cd /app/web && core/scripts/drupal recipe ../recipes/wunder_next_setup
       drush cr

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -11,6 +11,7 @@ php:
     DRUPAL_REVALIDATE_SECRET: revalidate_secret_not_secure_used_only_locally
     DRUPAL_CLIENT_SECRET: drupal_client_secret_not_secure_used_only_locally
     DRUPAL_CLIENT_ID: drupal-client-id
+    DRUPAL_ADMIN_PWD: <|drupal_admin_pwd|>
   hashsalt: notsosecurehashnotsosecurehashnotsosecurehash
   # This section is used in the template only, it will reinstall the site and apply
   # all standard configuration at each commit. When creating a new project from this template


### PR DESCRIPTION
Changes proposed in this PR: use a circleCI environment variable to set tjthe admin password for drupal with `drush si` to avoid declaring the password to the world.


At this link you can see that the password is not output anymore after installation.
https://app.circleci.com/pipelines/github/wunderio/next4drupal-project/317/workflows/978fdde6-6305-4e5c-98d1-7d5b86a5c40c/jobs/1281?invite=true#step-125-88 