### PR TITLE
NEX-65: Add image fields to Page and Frontpage, and improve descriptions for Excerpt fields.

### DIFF
--- a/drupal/recipes/wunder_base/config/field.field.node.article.field_excerpt.yml
+++ b/drupal/recipes/wunder_base/config/field.field.node.article.field_excerpt.yml
@@ -10,7 +10,7 @@ field_name: field_excerpt
 entity_type: node
 bundle: article
 label: Excerpt
-description: 'Add an excerpt for this piece of content. '
+description: 'Add an excerpt for this piece of content. It will also be used for search results and HTML meta tags.'
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/core.entity_form_display.node.frontpage.default.yml
+++ b/drupal/recipes/wunder_pages/config/core.entity_form_display.node.frontpage.default.yml
@@ -5,12 +5,15 @@ dependencies:
   config:
     - field.field.node.frontpage.field_content_elements
     - field.field.node.frontpage.field_excerpt
+    - field.field.node.frontpage.field_image
+    - image.style.thumbnail
     - node.type.frontpage
   module:
+    - image
     - paragraphs
     - path
 _core:
-  default_config_hash: ND3yUSm3MFSXotvO-ej9G_2zOkhyHH7DE3tbHjYotOc
+  default_config_hash: G3ibHuWxfMkwyWDipQFUULAr0Ssc_9FE7j2tyxypP58
 id: node.frontpage.default
 targetEntityType: node
 bundle: frontpage
@@ -18,13 +21,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   field_content_elements:
     type: paragraphs
-    weight: 9
+    weight: 10
     region: content
     settings:
       title: Paragraph
@@ -49,22 +52,30 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_image:
+    type: image_image
+    weight: 2
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 6
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 8
+    weight: 9
     region: content
     settings:
       display_label: true
@@ -78,13 +89,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 3
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -93,7 +104,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/drupal/recipes/wunder_pages/config/core.entity_form_display.node.page.default.yml
+++ b/drupal/recipes/wunder_pages/config/core.entity_form_display.node.page.default.yml
@@ -5,12 +5,15 @@ dependencies:
   config:
     - field.field.node.page.field_content_elements
     - field.field.node.page.field_excerpt
+    - field.field.node.page.field_image
+    - image.style.thumbnail
     - node.type.page
   module:
+    - image
     - paragraphs
     - path
 _core:
-  default_config_hash: ayBgrpPqLIvLg07UyvB8RiMCzw9xYH2lrYdyZuxjjAs
+  default_config_hash: hf8MYQonqWeY66p6OdYJDmvzcb747Skr1GPxfejywNY
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -18,13 +21,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   field_content_elements:
     type: paragraphs
-    weight: 11
+    weight: 12
     region: content
     settings:
       title: Paragraph
@@ -49,36 +52,44 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_image:
+    type: image_image
+    weight: 2
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 6
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 10
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true
@@ -92,13 +103,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 3
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -107,7 +118,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/drupal/recipes/wunder_pages/config/core.entity_view_display.node.frontpage.default.yml
+++ b/drupal/recipes/wunder_pages/config/core.entity_view_display.node.frontpage.default.yml
@@ -5,12 +5,13 @@ dependencies:
   config:
     - field.field.node.frontpage.field_content_elements
     - field.field.node.frontpage.field_excerpt
+    - field.field.node.frontpage.field_image
     - node.type.frontpage
   module:
     - entity_reference_revisions
     - user
 _core:
-  default_config_hash: 3Xdt21KCLrtwe41NAvn9JfAKnU7nnINYPWCrntRAzY4
+  default_config_hash: iQiEDwDbiX74dfrydqxMbIhomdQuAEQW2gj7Nr6jzho
 id: node.frontpage.default
 targetEntityType: node
 bundle: frontpage
@@ -23,19 +24,20 @@ content:
       view_mode: default
       link: ''
     third_party_settings: {  }
-    weight: 101
+    weight: 1
     region: content
   field_excerpt:
     type: basic_string
     label: above
     settings: {  }
     third_party_settings: {  }
-    weight: 102
+    weight: 2
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 0
     region: content
 hidden:
+  field_image: true
   langcode: true

--- a/drupal/recipes/wunder_pages/config/core.entity_view_display.node.frontpage.teaser.yml
+++ b/drupal/recipes/wunder_pages/config/core.entity_view_display.node.frontpage.teaser.yml
@@ -6,11 +6,12 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.frontpage.field_content_elements
     - field.field.node.frontpage.field_excerpt
+    - field.field.node.frontpage.field_image
     - node.type.frontpage
   module:
     - user
 _core:
-  default_config_hash: bmT95tKN2jV_pwSFTWhyOHDXQAJykqu8XdyfueAfCfI
+  default_config_hash: gLmDHKWLIH4eOMJnwqOpiPfRL8ys8jU5WaEvWlnpUHQ
 id: node.frontpage.teaser
 targetEntityType: node
 bundle: frontpage
@@ -24,4 +25,5 @@ content:
 hidden:
   field_content_elements: true
   field_excerpt: true
+  field_image: true
   langcode: true

--- a/drupal/recipes/wunder_pages/config/core.entity_view_display.node.page.default.yml
+++ b/drupal/recipes/wunder_pages/config/core.entity_view_display.node.page.default.yml
@@ -5,12 +5,13 @@ dependencies:
   config:
     - field.field.node.page.field_content_elements
     - field.field.node.page.field_excerpt
+    - field.field.node.page.field_image
     - node.type.page
   module:
     - entity_reference_revisions
     - user
 _core:
-  default_config_hash: XiCGemc-GS3dc4PksH4TSOAhafhuAZrjjwx2CJ63qGY
+  default_config_hash: qxlb1jPfrVIESUefBGl9EDfUz9v5z0lCzQVeLLFlZIc
 id: node.page.default
 targetEntityType: node
 bundle: page
@@ -33,5 +34,6 @@ content:
     weight: 1
     region: content
 hidden:
+  field_image: true
   langcode: true
   links: true

--- a/drupal/recipes/wunder_pages/config/core.entity_view_display.node.page.teaser.yml
+++ b/drupal/recipes/wunder_pages/config/core.entity_view_display.node.page.teaser.yml
@@ -6,11 +6,12 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.field_content_elements
     - field.field.node.page.field_excerpt
+    - field.field.node.page.field_image
     - node.type.page
   module:
     - user
 _core:
-  default_config_hash: 6gWZafBVr9iRwbQgOj5M5OvUIhDwTtD9htcQK3x5e74
+  default_config_hash: 2hxVAu6KzbekpXwknePR-UJFJU32bj8lc4M-9VdUKh8
 id: node.page.teaser
 targetEntityType: node
 bundle: page
@@ -24,4 +25,5 @@ content:
 hidden:
   field_content_elements: true
   field_excerpt: true
+  field_image: true
   langcode: true

--- a/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_excerpt.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_excerpt.yml
@@ -10,7 +10,7 @@ field_name: field_excerpt
 entity_type: node
 bundle: frontpage
 label: Excerpt
-description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling html meta tags."
+description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling HTML meta tags."
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_excerpt.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_excerpt.yml
@@ -10,7 +10,7 @@ field_name: field_excerpt
 entity_type: node
 bundle: frontpage
 label: Excerpt
-description: ''
+description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling html meta tags."
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_excerpt.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_excerpt.yml
@@ -10,7 +10,7 @@ field_name: field_excerpt
 entity_type: node
 bundle: frontpage
 label: Excerpt
-description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling HTML meta tags."
+description: "Add an excerpt for this piece of content. It will also be used for search results and HTML meta tags."
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_image.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_image.yml
@@ -1,0 +1,45 @@
+uuid: 92283c36-8fc3-46d0-a26e-3bf62c92981a
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - node.type.frontpage
+  module:
+    - content_translation
+    - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
+id: node.frontpage.field_image
+field_name: field_image
+entity_type: node
+bundle: frontpage
+label: 'Search/Meta Image'
+description: 'Image used in the search results and for Open Graph html meta tags, so that sharing the content looks good.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 1MB
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_image.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.frontpage.field_image.yml
@@ -19,7 +19,7 @@ field_name: field_image
 entity_type: node
 bundle: frontpage
 label: 'Search/Meta Image'
-description: 'Image used in the search results and for Open Graph html meta tags, so that sharing the content looks good.'
+description: 'Image used in the search results and for Open Graph HTML meta tags, so that sharing the content looks good.'
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.page.field_excerpt.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.page.field_excerpt.yml
@@ -10,7 +10,7 @@ field_name: field_excerpt
 entity_type: node
 bundle: page
 label: Excerpt
-description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling HTML meta tags."
+description: 'Add an excerpt for this piece of content. It will also be used for search results and HTML meta tags.'
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.page.field_excerpt.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.page.field_excerpt.yml
@@ -10,7 +10,7 @@ field_name: field_excerpt
 entity_type: node
 bundle: page
 label: Excerpt
-description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling html meta tags."
+description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling HTML meta tags."
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.page.field_excerpt.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.page.field_excerpt.yml
@@ -10,7 +10,7 @@ field_name: field_excerpt
 entity_type: node
 bundle: page
 label: Excerpt
-description: 'Add an excerpt for this piece of content. '
+description: "Add an excerpt for this piece of content. It's also used in the search system to show search results and also for compiling html meta tags."
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.page.field_image.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.page.field_image.yml
@@ -19,7 +19,7 @@ field_name: field_image
 entity_type: node
 bundle: page
 label: 'Search/Meta Image'
-description: 'Image used in the search results and for Open Graph html meta tags, so that sharing the content looks good.'
+description: 'Image used in the search results and for Open Graph HTML meta tags, so that sharing the content looks good.'
 required: false
 translatable: true
 default_value: {  }

--- a/drupal/recipes/wunder_pages/config/field.field.node.page.field_image.yml
+++ b/drupal/recipes/wunder_pages/config/field.field.node.page.field_image.yml
@@ -1,0 +1,45 @@
+uuid: 22892441-eb73-40d2-8b4a-89cb66e65c27
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - node.type.page
+  module:
+    - content_translation
+    - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
+id: node.page.field_image
+field_name: field_image
+entity_type: node
+bundle: page
+label: 'Search/Meta Image'
+description: 'Image used in the search results and for Open Graph html meta tags, so that sharing the content looks good.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 1MB
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image


### PR DESCRIPTION
https://wunder.atlassian.net/browse/NEX-65

*Changes proposed in this PR:*
- Improve the description of Excerpt field so that editors understand it's used for Search and Metatags also. 
- Add image fields to Frontpage and Page so that they will be used in the og:image and search. 

*Link to feature environment:*
https://feature-nex-65-next.next4drupal-project.dev.wdr.io/
