### PR TITLE
Prevent header items styles breaking just above mobile breakpoint

### DIFF
--- a/next/components/user-menu.tsx
+++ b/next/components/user-menu.tsx
@@ -73,7 +73,7 @@ export function UserMenu() {
       <span className="sr-only">{t("user-menu")}</span>
       <button type="button" className="hover:underline" onClick={toggle}>
         <span className="hidden sm:mr-2 sm:inline">
-          {t("log-in-or-register")}
+          {t("user-menu-account")}
         </span>
         <AccountIcon className="inline-block h-6 w-6" />
       </button>

--- a/next/public/locales/en/common.json
+++ b/next/public/locales/en/common.json
@@ -63,5 +63,5 @@
   "email": "Email",
   "register": "Create account",
   "register-success": "You are now registered. Check your email for a confirmation link where you will be able to set your password.",
-  "log-in-or-register": "Log in - Create account"
+  "user-menu-account": "Account"
 }

--- a/next/public/locales/fi/common.json
+++ b/next/public/locales/fi/common.json
@@ -63,5 +63,5 @@
   "email": "Sähköposti",
   "register": "Rekisteröidy",
   "register-success": "Olet nyt rekisteröitynyt. Tarkista sähköpostistasi vahvistuslinkki, jolla voit asettaa salasanasi.",
-  "log-in-or-register": "Kirjaudu sisään / rekisteröidy"
+  "user-menu-account": "Tilini"
 }

--- a/next/public/locales/sv/common.json
+++ b/next/public/locales/sv/common.json
@@ -63,5 +63,5 @@
   "email": "E-post",
   "register": "Registrera",
   "register-success": "Du är nu registrerad. Kontrollera din e-post för en bekräftelselänk där du kommer att kunna ange ditt lösenord.",
-  "log-in-or-register": "Logga in / registrera dig"
+  "user-menu-account": "Konto"
 }


### PR DESCRIPTION
Before:

![image](https://github.com/wunderio/next4drupal-project/assets/22575651/b658e8f5-5918-4d11-b336-af319120cdf9)


After:

<img width="647" alt="CleanShot 2023-05-12 at 16 03 11@2x" src="https://github.com/wunderio/next4drupal-project/assets/22575651/58d1a437-471f-48d9-a35e-61398a68d5d5">
