### PR TITLE
DO NOT MERGE: NEX-71: Demonstrate having a different language as default

### DIFF
--- a/drupal/recipes/wunder_languages/config/language.negotiation.yml
+++ b/drupal/recipes/wunder_languages/config/language.negotiation.yml
@@ -10,3 +10,5 @@ url:
     en: ''
     fi: ''
     sv: ''
+selected_langcode: fi
+

--- a/next/next-i18next.config.js
+++ b/next/next-i18next.config.js
@@ -2,6 +2,7 @@ const config = require("./site.config");
 
 module.exports = {
   i18n: {
+    localeDetection: false,
     defaultLocale: config.defaultLocale,
     locales: Object.keys(config.locales),
   },

--- a/next/site.config.js
+++ b/next/site.config.js
@@ -1,9 +1,9 @@
 const siteConfig = {
-  defaultLocale: "en",
+  defaultLocale: "fi",
   locales: {
     en: {
       name: "English",
-      path: "/",
+      path: "/en",
       langcode: "en",
     },
     fi: {


### PR DESCRIPTION
This draft PR is a test to show how to set a different language than english as default.

* We are setting finnish as selected language (not default) on the drupal side

* We are disabling automatic detection of next.js

* We are setting finnish as default language in next.js

