### PR TITLE
NEX-77: Add language links for search page

### DIFF
--- a/next/lib/contexts/language-links-context.tsx
+++ b/next/lib/contexts/language-links-context.tsx
@@ -1,3 +1,4 @@
+import { GetStaticPropsContext } from "next";
 import { createContext, useContext } from "react";
 
 import siteConfig from "@/site.config";
@@ -18,6 +19,27 @@ export function createLanguageLinks(
   const languageLinks = JSON.parse(JSON.stringify(siteConfig.locales));
   Object.entries(nodeTranslations).forEach(([key, path]) => {
     languageLinks[key].path = path;
+  });
+  return languageLinks;
+}
+
+/**
+ * Generates a language links object for a page that is created in next only.
+ * @param path
+ *   The path of the page.
+ * @param context
+ *   The context.
+ */
+export function createLanguageLinksForNextOnlyPage(
+  path: string,
+  context: GetStaticPropsContext
+): LanguageLinks {
+  const languageLinks = JSON.parse(JSON.stringify(siteConfig.locales));
+  context.locales.forEach((locale) => {
+    languageLinks[locale].path =
+      languageLinks[locale].path === "/"
+        ? path
+        : `${languageLinks[locale].path}${path}`;
   });
   return languageLinks;
 }

--- a/next/pages/search.tsx
+++ b/next/pages/search.tsx
@@ -32,6 +32,10 @@ import { buildState } from "@/lib/search-ui-helpers/buildState";
 import { runRequest } from "@/lib/search-ui-helpers/runRequest";
 import { useNextRouting } from "@/lib/search-ui-helpers/useNextRouting";
 
+interface SearchPageProps extends CommonPageProps {
+  languageLinks: LanguageLinks;
+}
+
 export default function SearchPage() {
   const { t } = useTranslation();
   const router = useRouter();
@@ -120,9 +124,11 @@ export default function SearchPage() {
   );
 }
 
-export const getStaticProps: GetStaticProps<CommonPageProps> = async (
+export const getStaticProps: GetStaticProps<SearchPageProps> = async (
   context
 ) => {
+  // We have to pass the path of the page manually here, it would be better to infer it
+  // automatically, but apparently this is not doable in this context.
   const languageLinks = createLanguageLinksForNextOnlyPage("/search", context);
 
   return {

--- a/next/pages/search.tsx
+++ b/next/pages/search.tsx
@@ -20,6 +20,10 @@ import { Pagination } from "@/components/search/search-pagination";
 import { PagingInfoView } from "@/components/search/search-paging-info";
 import { SearchResult } from "@/components/search/search-result";
 import {
+  createLanguageLinksForNextOnlyPage,
+  LanguageLinks,
+} from "@/lib/contexts/language-links-context";
+import {
   CommonPageProps,
   getCommonPageProps,
 } from "@/lib/get-common-page-props";
@@ -119,9 +123,12 @@ export default function SearchPage() {
 export const getStaticProps: GetStaticProps<CommonPageProps> = async (
   context
 ) => {
+  const languageLinks = createLanguageLinksForNextOnlyPage("/search", context);
+
   return {
     props: {
       ...(await getCommonPageProps(context)),
+      languageLinks,
     },
     revalidate: 60,
   };


### PR DESCRIPTION
*Changes proposed in this PR:*
- add a new function that can be used on "next-only" pages, like the /search page, to calculate language links. Currently, switching language while on the search page takes the user to the frontpage. With these changes, the user is taken to the search page in the requested language.

*How to test:*
1. Go to the search page, try to switch languages.
