### PR TITLE
NEX-77: Language links for next-only pages

### DIFF
--- a/next/lib/contexts/language-links-context.tsx
+++ b/next/lib/contexts/language-links-context.tsx
@@ -1,3 +1,4 @@
+import { GetStaticPropsContext } from "next";
 import { createContext, useContext } from "react";
 
 import siteConfig from "@/site.config";
@@ -18,6 +19,27 @@ export function createLanguageLinks(
   const languageLinks = JSON.parse(JSON.stringify(siteConfig.locales));
   Object.entries(nodeTranslations).forEach(([key, path]) => {
     languageLinks[key].path = path;
+  });
+  return languageLinks;
+}
+
+/**
+ * Generates a language links object for a page that is created in next only.
+ * @param path
+ *   The path of the page.
+ * @param context
+ *   The context.
+ */
+export function createLanguageLinksForNextOnlyPage(
+  path: string,
+  context: GetStaticPropsContext
+): LanguageLinks {
+  const languageLinks = JSON.parse(JSON.stringify(siteConfig.locales));
+  context.locales.forEach((locale) => {
+    languageLinks[locale].path =
+      languageLinks[locale].path === "/"
+        ? path
+        : `${languageLinks[locale].path}${path}`;
   });
   return languageLinks;
 }

--- a/next/pages/all-articles/[[...page]].tsx
+++ b/next/pages/all-articles/[[...page]].tsx
@@ -7,6 +7,10 @@ import { HeadingPage } from "@/components/heading--page";
 import { LayoutProps } from "@/components/layout";
 import { Meta } from "@/components/meta";
 import { Pagination, PaginationProps } from "@/components/pagination";
+import {
+  createLanguageLinksForNextOnlyPage,
+  LanguageLinks,
+} from "@/lib/contexts/language-links-context";
 import { getLatestArticlesItems } from "@/lib/get-articles";
 import { getCommonPageProps } from "@/lib/get-common-page-props";
 import {
@@ -17,6 +21,7 @@ import {
 interface AllArticlesPageProps extends LayoutProps {
   articleTeasers: ArticleTeaserType[];
   paginationProps: PaginationProps;
+  languageLinks: LanguageLinks;
 }
 
 export default function AllArticlesPage({
@@ -85,6 +90,11 @@ export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async (
       : prevEnabled && [pageRoot, prevPage].join("/");
   const nextPageHref = nextEnabled && [pageRoot, nextPage].join("/");
 
+  // Create language links for this page.
+  // Note: the links will always point to the first page, because we cannot guarantee that
+  // the other pages will exist in all languages.
+  const languageLinks = createLanguageLinksForNextOnlyPage(pageRoot, context);
+
   return {
     props: {
       ...(await getCommonPageProps(context)),
@@ -99,6 +109,7 @@ export const getStaticProps: GetStaticProps<AllArticlesPageProps> = async (
         prevPageHref,
         nextPageHref,
       },
+      languageLinks,
     },
     revalidate: 60,
   };


### PR DESCRIPTION
Currently, for next-only pages, when switching languages the user is taken to the homepage for that language: 

1. user is on `/all-articles`
2. user switches to Swedish using the language selector
3. user is taken to `/sv`

This PR changes this so that the user is taken to `sv/all-articles`

This needs to be applied manually to each page, and has these limitations: 
1. The path of the page needs to be hard-coded, because in the context of `getStaticProps` we can't know the path of the page (as weird as it feels, this seems to be the case)
2. We cannot add this for the `/search` page, because switching languages does not refresh the search results, and so the user would get an inconsistent UI. So for the search page, switching languages will take people to the frontpage.

So this PR adds this only for the `all-articles` page, but it can then be extended in the future to other pages that we will make.
