### PR TITLE
NEX-82: Allow the heading of the accordion to be empty

### DIFF
--- a/next/lib/zod/paragraph.ts
+++ b/next/lib/zod/paragraph.ts
@@ -112,7 +112,7 @@ const AccordionItemSchema = z.object({
 
 export const AccordionSchema = z.object({
   type: z.literal("paragraph--accordion"),
-  id: z.string(),
+  id: z.string().nullable(),
   field_heading: z.string(),
   field_accordion_items: z.array(AccordionItemSchema),
 });

--- a/next/lib/zod/paragraph.ts
+++ b/next/lib/zod/paragraph.ts
@@ -112,8 +112,8 @@ const AccordionItemSchema = z.object({
 
 export const AccordionSchema = z.object({
   type: z.literal("paragraph--accordion"),
-  id: z.string().nullable(),
-  field_heading: z.string(),
+  id: z.string(),
+  field_heading: z.string().nullable(),
   field_accordion_items: z.array(AccordionItemSchema),
 });
 export const HeroSchema = z.object({

--- a/next/wunder-component-library/accordion.tsx
+++ b/next/wunder-component-library/accordion.tsx
@@ -4,7 +4,7 @@ import ChevronIcon from "@/styles/icons/chevron-down.svg";
 import ListIcon from "@/styles/icons/list.svg";
 
 interface AccordionProps {
-  heading: string | React.ReactNode;
+  heading?: string | React.ReactNode;
   items: Array<{
     id: string;
     heading: string | React.ReactNode;
@@ -14,9 +14,11 @@ interface AccordionProps {
 export function Accordion({ heading, items }: AccordionProps) {
   return (
     <div className="relative h-full rounded border border-finnishwinter bg-white p-4 transition-all hover:shadow-md">
-      <h2 className="mb-4 text-heading-sm font-bold md:text-heading-md">
-        {heading}
-      </h2>
+      {heading && (
+        <h2 className="mb-4 text-heading-sm font-bold md:text-heading-md">
+          {heading}
+        </h2>
+      )}
       <AccordionUI.Root type="single" collapsible className="grid gap-4">
         {items?.map((item) => (
           <AccordionUI.Item key={item.id} value={item.id}>


### PR DESCRIPTION
This PR fixes a mismatch between Drupal settings for the accordion and its Zod schema.

## To test:

1. pick an existing page with an accordion, edit it, remove the accordion title, save the page
2. the page should still display correctly

Example on Silta feature branch:

Drupal: https://feature-nex-81.next4drupal-project.dev.wdr.io/en/node/17/edit
Next: https://feature-nex-81-next.next4drupal-project.dev.wdr.io/en/media-and-publishing


![image](https://github.com/wunderio/next4drupal-project/assets/185412/38304875-0ab7-4952-83ae-1979f2289502)



