### PR TITLE
Use supported mimetype for .mjs

### DIFF
--- a/silta/silta-storybook.yml
+++ b/silta/silta-storybook.yml
@@ -9,5 +9,8 @@ nginx:
   extraConfig: |
     include mime.types;
     types {
+        # Base Silta config uses "application/octet-stream" for .mjs.
+        # Browsers will refuse to run any JS files served with such mimetype.
+        # Setting mimetype to "text/javascript" will make it work.
         text/javascript mjs;
     }

--- a/silta/silta-storybook.yml
+++ b/silta/silta-storybook.yml
@@ -8,6 +8,6 @@ nginx:
     wunder-vpn: 194.89.156.118/32
   extraConfig: |
     include mime.types;
-        types {
-            application/javascript mjs;
+    types {
+        text/javascript mjs;
     }


### PR DESCRIPTION
No ticket, 1-line fix.

*Changes proposed in this PR:*
- Use `text/javascript` instead of legacy `application/javascript`

*How to test:*
1. Check that Storybook still loads.

*Reasoning:*

https://datatracker.ietf.org/doc/rfc9239/

- Better align with current standards
    - `text/javascript` is now the only "proper" mimetype for JavaScript files
    - other types such as `application/javascript` alias to `text/javascript`
- Avoid magical thinking
    - If someone looking at silta-storybook.yml doesn't know about RFC9239, they might think that there has been some good reason to use specifically `application/javascript` for .mjs
    - This could cause them to start always setting that mimetype for .mjs or even all .js, without knowing why it's done or what is affected by doing so (= magical thinking)
