### PR TITLE
NEX-90: Add missing permissions to the next_api role to view all revisions

### DIFF
--- a/drupal/recipes/wunder_next_setup/config/user.role.next_api_role.yml
+++ b/drupal/recipes/wunder_next_setup/config/user.role.next_api_role.yml
@@ -13,3 +13,5 @@ permissions:
   - 'access user profiles'
   - 'bypass node access'
   - 'issue subrequests'
+  - 'view all revisions'
+  - 'view all media revisions'


### PR DESCRIPTION
* this fixes errors when viewing past revisions links.

There is one complication though, when viewing a past revision of the PAGE content type, that has paragraphs, the paragraphs are shown at their _current_ revision. (I think it's a limitation of jsonapi + paragraphs)

So in practice this is not really useful for content with paragraphs.


## Examples


### Articles content type (no paragraphs, standard body field + image)

This works nicely!
![image](https://github.com/wunderio/next4drupal-project/assets/185412/7c581a46-9629-4ca8-b691-dc53e04e90df)

### Page content type (made of paragraphs)

Paragraphs are shown at their last version in any case, making what is shown misleading for users:

![image](https://github.com/wunderio/next4drupal-project/assets/185412/4c87bf53-8699-4405-956c-be367a17320c)


