### PR TITLE
NEX-90: Add patch to show paragraphs at correct revision when showing preview of a node revision

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -137,7 +137,8 @@
                 "Fix error when enabling the language module via recipe": "https://www.drupal.org/files/issues/2019-11-19/drupal.8.8.x-3002532-20.patch",
                 "Set MenuLinkContent getEntity to public visibility": "https://www.drupal.org/files/issues/2022-05-16/2997790-40.patch",
                 "Add link fields to jsonapi response": "https://www.drupal.org/files/issues/2022-03-04/3066751-68.patch",
-                "Do not set user as blocked when created via REST": "https://www.drupal.org/files/issues/2022-08-17/3055807-47.patch"
+                "Do not set user as blocked when created via REST": "https://www.drupal.org/files/issues/2022-08-17/3055807-47.patch",
+                "Return correct revisions of paragraphs in preview json api response": "https://www.drupal.org/files/issues/2022-09-27/3088239-33.patch"
             }
         },
         "dropin-paths": {


### PR DESCRIPTION
With "vanilla" drupal core, when you request a node with paragraphs at a specified revision via JSONApi, the paragraphs will be returned at their most recent version. This is a problem for us here, because when a content editor clicks on a revision, they expect to see the node (and its paragraph) as they were at that point in history.

As suggested on https://github.com/chapter-three/next-drupal/issues/509 , we are now adding this patch:

* more info at: https://www.drupal.org/project/drupal/issues/3088239#comment-14708895

That seems to solve the problem nicely:

![image](https://github.com/wunderio/next4drupal-project/assets/185412/e095583f-c8b7-4655-aa32-2a990b734240)



To test:

1. pick a page
2. edit the page, add an edit to a paragraph content (for example, add text like in the screenshot)
3. visit the "Revisions" tab
4. view the node at the original revision: you should not see the change that you have made in 2.
5. view the node at the current most recent revision, your change should be there.

