### PR TITLE
NEX-89: Fix for html parsing in wysiwyg areas

### DIFF
--- a/next/components/formatted-text.tsx
+++ b/next/components/formatted-text.tsx
@@ -52,7 +52,7 @@ const options: HTMLReactParserOptions = {
         if (href && isRelative(href)) {
           return (
             <Link href={href} className="hyperlink underline">
-              {domToReact(domNode.children)}
+              {domToReact(domNode.children, options)}
             </Link>
           );
         }
@@ -60,7 +60,7 @@ const options: HTMLReactParserOptions = {
       }
 
       case "p": {
-        return <p className="mb-2">{domToReact(domNode.children)}</p>;
+        return <p className="mb-2">{domToReact(domNode.children, options)}</p>;
       }
 
       case "input": {


### PR DESCRIPTION
* Ensure nested elements are handled with the same options as top level elements

Before this change, elements within for example a <p> tag were parsed without any option specified. This caused for example nested images not to be correctly transformed into Next.js image components.
