### PR TITLE
NEX-93: Filter out null values when retrieving latest articles for client side listing

### DIFF
--- a/next/pages/api/articles-listing.ts
+++ b/next/pages/api/articles-listing.ts
@@ -31,9 +31,12 @@ export default async function handler(
       },
     );
 
-    const validatedArticleTeasers = articleTeasers.map((articleNode) =>
-      validateAndCleanupArticleTeaser(articleNode),
-    );
+    const validatedArticleTeasers = articleTeasers
+      .map((articleNode) => validateAndCleanupArticleTeaser(articleNode))
+      // If any article teaser is invalid, it will be replaced by null in the array, so we need to filter it out:
+      .filter((teaser) => {
+        return teaser !== null;
+      });
 
     // Set cache headers: 60 seconds max-age, stale-while-revalidate
     res.setHeader("Cache-Control", "s-maxage=60, stale-while-revalidate");


### PR DESCRIPTION
## Link to ticket:

https://wunder.atlassian.net/browse/NEX-93 

## Changes proposed in this PR:

We have a listing that gets its data client-side, and we are using zod to validate the elements in the response. If any element does not pass validation, the array will have an item with `null`  as a value.

This is a problem for the frontend, and it can crash the site. This fix prevents it by filtering out the offending items from the array before it's returned.

## How to test:

Not too easy to test in silta, but locally you can try messing with the data, see that the article is filtered out:

![image](https://github.com/wunderio/next4drupal-project/assets/185412/6df9496e-1f8f-4612-8c73-80363a69710f)

