### PR TITLE
NEX-94: xml sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ The environment variables used by the frontend are also checked for type safety.
 3. Import it in the file where it's used with `import { env } from "@/env";` and use it like `env.MY_ENV_VAR`. At this point, your environment variable should be working locally.
 4. To ensure it also works in CircleCI and Silta, also add it to`.circleci/config.yml` and `silta-next.yml`.
 
+#### XML sitemap
+
+The Drupal backend is responsible for generating the xml sitemap with the `simple_sitemap` module and exporting it to a file using a custom module. The frontend then reads this file and serves it at `/sitemap.xml` via proxying.
+
 ### UI library
 
 The `ui/` directory contains some reusable UI components that are used in the frontend. These components are based on the [Wunder Component Library](https://www.figma.com/file/i0RIoStoPOZfcqS80DLbkD/The-Component-Library), which is a collection of reusable UI components designed to be used as a shared base for many projects. The components are meant to be used as a starting point, and should be modified, added and removed as required to fit the needs of the project.

--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -35,6 +35,7 @@
         "drupal/redirect": "^1.8",
         "drupal/require_login": "^3.0",
         "drupal/restui": "^1.21",
+        "drupal/simple_sitemap": "^4.1",
         "drupal/simplei": "^2.0@beta",
         "drupal/webform": "^6.2@beta",
         "drupal/webform_rest": "^4.0",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b22d9f91357520043b2390d247ebe82e",
+    "content-hash": "5363686aead0fbe71198f73fb306d9aa",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2953,6 +2953,63 @@
             "homepage": "https://www.drupal.org/project/simple_oauth",
             "support": {
                 "source": "https://git.drupalcode.org/project/simple_oauth"
+            }
+        },
+        {
+            "name": "drupal/simple_sitemap",
+            "version": "4.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/simple_sitemap.git",
+                "reference": "4.1.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/simple_sitemap-4.1.6.zip",
+                "reference": "4.1.6",
+                "shasum": "5ea5ee97ab4d59b43db86dd6279c3ac5ecbe69b9"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10",
+                "ext-xmlwriter": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.1.6",
+                    "datestamp": "1686288643",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": ">=9"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Pawel Ginalski (gbyte)",
+                    "homepage": "https://www.drupal.org/u/gbyte",
+                    "email": "contact@gbyte.dev",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "WalkingDexter",
+                    "homepage": "https://www.drupal.org/user/3251330"
+                }
+            ],
+            "description": "Creates a standard conform hreflang XML sitemap of the site content and provides a framework for developing other sitemap types.",
+            "homepage": "https://drupal.org/project/simple_sitemap",
+            "support": {
+                "source": "https://cgit.drupalcode.org/simple_sitemap",
+                "issues": "https://drupal.org/project/issues/simple_sitemap"
             }
         },
         {

--- a/drupal/recipes/wunder_base/config/simple_sitemap.bundle_settings.default.node.article.yml
+++ b/drupal/recipes/wunder_base/config/simple_sitemap.bundle_settings.default.node.article.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/drupal/recipes/wunder_base/config/simple_sitemap.custom_links.default.yml
+++ b/drupal/recipes/wunder_base/config/simple_sitemap.custom_links.default.yml
@@ -1,0 +1,7 @@
+_core:
+  default_config_hash: 25hWeYa4sasuJtHqKKcEN_nYiuEC1lMPYHsn5dawJEw
+links:
+  -
+    path: /
+    priority: '1.0'
+    changefreq: daily

--- a/drupal/recipes/wunder_base/config/simple_sitemap.settings.yml
+++ b/drupal/recipes/wunder_base/config/simple_sitemap.settings.yml
@@ -1,0 +1,20 @@
+_core:
+  default_config_hash: MUpaAk1hn-0Ph4OFw3DD_6gUF9KbGwxja9Y0qmampzo
+max_links: 2000
+cron_generate: true
+cron_generate_interval: 0
+generate_duration: 10000
+entities_per_queue_item: 50
+remove_duplicates: true
+skip_untranslated: true
+xsl: false
+base_url: ''
+default_variant: default
+custom_links_include_images: false
+disable_language_hreflang: false
+hide_branding: false
+excluded_languages: {  }
+enabled_entity_types:
+  - node
+  - taxonomy_term
+  - menu_link_content

--- a/drupal/recipes/wunder_base/config/simple_sitemap.sitemap.default.yml
+++ b/drupal/recipes/wunder_base/config/simple_sitemap.sitemap.default.yml
@@ -1,0 +1,13 @@
+uuid: c380a8bb-e49c-4ee6-b992-6758faba3795
+langcode: en
+status: true
+dependencies:
+  config:
+    - simple_sitemap.type.default_hreflang
+_core:
+  default_config_hash: zHW-ZT11Lkf2zSRgisGKjgU7TzrNcT8_MwFeuVtl8O8
+id: default
+label: Default
+description: 'The default hreflang sitemap - lists URLs to be indexed by modern search engines.'
+type: default_hreflang
+weight: 0

--- a/drupal/recipes/wunder_base/config/simple_sitemap.sitemap.index.yml
+++ b/drupal/recipes/wunder_base/config/simple_sitemap.sitemap.index.yml
@@ -1,0 +1,13 @@
+uuid: ce58df4d-f920-46ac-a894-a15eea863985
+langcode: en
+status: false
+dependencies:
+  config:
+    - simple_sitemap.type.index
+_core:
+  default_config_hash: aJs7eKxEbjBloVrp0IuxQbeq25CNH0r9AhSS29kHFMw
+id: index
+label: 'Sitemap Index'
+description: 'The sitemap index listing all other sitemaps - useful if there are at least two other sitemaps. In most cases this sitemap should be last in the generation queue and set as the default sitemap.'
+type: index
+weight: 1000

--- a/drupal/recipes/wunder_base/config/simple_sitemap.type.default_hreflang.yml
+++ b/drupal/recipes/wunder_base/config/simple_sitemap.type.default_hreflang.yml
@@ -1,0 +1,15 @@
+uuid: 8ae7f34f-292d-469b-8ce9-c43904f3658c
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: pYORFuFzL0b2FKevz6fSag1wOUNTthFPPLxZ18JB1t0
+id: default_hreflang
+label: 'Default hreflang'
+description: 'The default hreflang sitemap type. A sitemap of this type is understood by most modern search engines.'
+sitemap_generator: default
+url_generators:
+  - custom
+  - entity
+  - entity_menu_link_content
+  - arbitrary

--- a/drupal/recipes/wunder_base/config/simple_sitemap.type.index.yml
+++ b/drupal/recipes/wunder_base/config/simple_sitemap.type.index.yml
@@ -1,0 +1,12 @@
+uuid: e56aefbd-8ba6-4493-b754-ee8b9900196b
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: pbgJrin6L7zsVEKS8oEDCYJPCzgu765iTGQh2GPX1no
+id: index
+label: 'Sitemap Index'
+description: 'The sitemap index sitemap type. A sitemap of this type lists sitemaps of all other types.'
+sitemap_generator: index
+url_generators:
+  - index

--- a/drupal/recipes/wunder_base/recipe.yml
+++ b/drupal/recipes/wunder_base/recipe.yml
@@ -34,6 +34,8 @@ install:
   - webform_ui
   - admin_toolbar
   - menu_link_attributes
+  - simple_sitemap
+  - wunder_sitemap
 
 config:
   import:

--- a/drupal/recipes/wunder_pages/config/simple_sitemap.bundle_settings.default.node.page.yml
+++ b/drupal/recipes/wunder_pages/config/simple_sitemap.bundle_settings.default.node.page.yml
@@ -1,0 +1,4 @@
+index: true
+priority: '0.5'
+changefreq: ''
+include_images: false

--- a/drupal/web/modules/custom/wunder_sitemap/src/SitemapExporter.php
+++ b/drupal/web/modules/custom/wunder_sitemap/src/SitemapExporter.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\wunder_sitemap;
+
+use Drupal\Core\File\Exception\FileException;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\simple_sitemap\Manager\Generator;
+
+/**
+ * Contains methods to export a sitemap to a file.
+ */
+class SitemapExporter {
+
+  /**
+   * Drupal\Core\Logger\LoggerChannelInterface definition.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected LoggerChannelInterface $loggerChannelTeklacomSitemap;
+
+  /**
+   * Drupal\simple_sitemap\Manager\Generator definition.
+   *
+   * @var \Drupal\simple_sitemap\Manager\Generator
+   */
+  protected Generator $simpleSitemapGenerator;
+
+  /**
+   * Drupal\Core\File\FileSystem definition.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected FileSystemInterface $fileSystem;
+
+  /**
+   * Constructs a new TeklacomSitemapExporter object.
+   */
+  public function __construct(LoggerChannelInterface $logger_channel_wunder_sitemap, Generator $simple_sitemap_generator, FileSystemInterface $fileSystem) {
+    $this->loggerChannelTeklacomSitemap = $logger_channel_wunder_sitemap;
+    $this->simpleSitemapGenerator = $simple_sitemap_generator;
+    $this->fileSystem = $fileSystem;
+  }
+
+  /**
+   * Exports a sitemap (created by the simple_sitemap module to a file)
+   *
+   * @param string $variant
+   *   The variant of the sitemap, according to simple_sitemap config.
+   * @param string $filepath
+   *   The path to save the file to.
+   */
+  public function exportSitemapToFile($variant, $filepath): void {
+    // Get the current sitemap:
+    $output = $this->simpleSitemapGenerator->setVariants($variant)->getContent();
+    // Delete the existing file, otherwise s3 will not overwrite it:
+    try {
+      $this->fileSystem->delete($filepath);
+    }
+    catch (FileException $e) {
+      $this->loggerChannelTeklacomSitemap->error('Error deleting existing sitemap file: @error', [
+        '@error' =>
+        $e->getMessage(),
+      ]);
+    }
+    // Save a new file with the contents:
+    $saved_path = $this->fileSystem->saveData($output, $filepath, $this->fileSystem::EXISTS_REPLACE);
+    if ($saved_path) {
+      $this->loggerChannelTeklacomSitemap->info('Sitemap exported to the filepath: @filepath', [
+        '@filepath' =>
+        $saved_path,
+      ]);
+    }
+    else {
+      $this->loggerChannelTeklacomSitemap->error('Sitemap could not be exported to the requested filepath: @requested_filepath', [
+        '@requested_filepath' =>
+        $filepath,
+      ]);
+    }
+  }
+
+}

--- a/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.info.yml
+++ b/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.info.yml
@@ -1,0 +1,7 @@
+name: 'Wunder Sitemap'
+type: module
+description: 'Additional functionality to generate the sitemap for a decoupled site.'
+package: Trimble
+core_version_requirement: ^9 || ^10
+dependencies:
+  - simple_sitemap:simple_sitemap

--- a/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.module
+++ b/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Contains wunder_sitemap.module.
+ */
+
+/**
+ * Implements hook_cron().
+ */
+function wunder_sitemap_cron() {
+  /** @var \Drupal\wunder_sitemap\SitemapExporter $sitemap_exporter */
+  $sitemap_exporter = \Drupal::service("wunder_sitemap.exporter");
+  $sitemap_exporter->exportSitemapToFile('default', 'public://sitemap.xml');
+}

--- a/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.services.yml
+++ b/drupal/web/modules/custom/wunder_sitemap/wunder_sitemap.services.yml
@@ -1,0 +1,7 @@
+services:
+  logger.channel.wunder_sitemap:
+    parent: logger.channel_base
+    arguments: ['wunder_sitemap']
+  wunder_sitemap.exporter:
+    class: Drupal\wunder_sitemap\SitemapExporter
+    arguments: ['@logger.channel.wunder_sitemap', '@simple_sitemap.generator', '@file_system']

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -51,6 +51,9 @@ $settings['wunder_next.settings']['revalidate_secret'] = $_ENV['DRUPAL_REVALIDAT
 $settings['wunder_next.settings']['client_secret'] = $_ENV['DRUPAL_CLIENT_SECRET'];
 $settings['wunder_next.settings']['client_id'] = $_ENV['DRUPAL_CLIENT_ID'];
 
+// Use the frontend site URL to create links in the xml sitemap:
+$config['simple_sitemap.settings']['base_url'] = $_ENV['WUNDER_NEXT_FRONTEND_URL'];
+
 // Environment-specific settings.
 $env = $_ENV['ENVIRONMENT_NAME'];
 switch ($env) {

--- a/silta/silta-next.yml
+++ b/silta/silta-next.yml
@@ -21,6 +21,21 @@ services:
       NEXTAUTH_URL: https://<|NEXT_DOMAIN|>
 
 nginx:
+  extra_conditions: |
+    # Pass through sitemap.xml requests to Drupal.
+    location = /sitemap.xml {
+      proxy_pass https://<|DRUPAL_DOMAIN|>/sites/default/files/sitemap.xml;
+      proxy_http_version 1.1;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-NginX-Proxy true;
+      proxy_ssl_session_reuse off;
+      proxy_redirect off;
+      proxy_pass_request_headers on;
+      proxy_pass_request_body on;
+      add_header Cache-Control "max-age=0";
+      access_log off;
+    }
   content_security_policy: >- # Lines below are joined without line breaks.
     upgrade-insecure-requests;
     default-src 'none';


### PR DESCRIPTION
## Link to feature environment:

https://feature-nex-94-next.next4drupal.dev.wdr.io/sitemap.xml 

## Changes proposed in this PR:

This feature branch adds a xml sitemap to the template.

It works like this:

* we add the `simple_sitemap` module to Drupal, and configure it so that:
  * the sitemap is created in a single file
  * the sitemap includes `article` and `page` content types only
  * the sitemap uses the base url of the frontend to generate the links instead of the backend base url
* we add a custom drupal module that exports the sitemap into an actual xml file to the files directory at each cron run
* we add a rewrite to the frontend part of the silta setup, so that if a visitor visits the `/sitemap.xml` path on the frontend, the browser will be served the contents of the xml file from drupal's file directory.  


## How to test:

1. create a new content
2. run cron on the drupal site
3. visit frontend/sitemap.xml 

you should find your link in the sitemap.


> note: cron needs to be *at least once*  for this to work.