### PR TITLE
NEX-94: Move the proxying for the sitemap from silta to next rewrites

### DIFF
--- a/next/next.config.js
+++ b/next/next.config.js
@@ -8,7 +8,14 @@ const nextConfig = {
   },
   i18n,
   async rewrites() {
-    return [];
+    return {
+      beforeFiles: [
+        {
+          source: "/sitemap.xml",
+          destination: `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/sites/default/files/sitemap.xml`,
+        },
+      ],
+    };
   },
   webpack(config) {
     config.module.rules.push({

--- a/silta/silta-next.yml
+++ b/silta/silta-next.yml
@@ -21,21 +21,6 @@ services:
       NEXTAUTH_URL: https://<|NEXT_DOMAIN|>
 
 nginx:
-  extra_conditions: |
-    # Pass through sitemap.xml requests to Drupal.
-    location = /sitemap.xml {
-      proxy_pass https://<|DRUPAL_DOMAIN|>/sites/default/files/sitemap.xml;
-      proxy_http_version 1.1;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header X-NginX-Proxy true;
-      proxy_ssl_session_reuse off;
-      proxy_redirect off;
-      proxy_pass_request_headers on;
-      proxy_pass_request_body on;
-      add_header Cache-Control "max-age=0";
-      access_log off;
-    }
   content_security_policy: >- # Lines below are joined without line breaks.
     upgrade-insecure-requests;
     default-src 'none';


### PR DESCRIPTION
This Pr switches to next rewrites instead of silta redirects for the proxying of the sitemap.

This makes it simpler and more generic. 