### PR TITLE
NEX-38: Support multilingual redirects, activate automatic creation of redirects when aliases are updated.

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -126,7 +126,7 @@
                 "Get same results on different request": "https://www.drupal.org/files/issues/2019-07-18/change_request_type-63049395-09.patch"
             },
             "drupal/decoupled_router": {
-                "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2022-12-01/decouple_router-3111456-resolve-language-issue-58--get-translation.patch"
+                "Unable to resolve path on node in other language than default": "https://www.drupal.org/files/issues/2023-04-27/decouple_router-3111456-resolve-language-issue-64--get-translation.patch"
             },
             "drupal/jsonapi_menu_items": {
                 "Add info about the langcode for menu items (issue #3192576)": "https://www.drupal.org/files/issues/2023-02-10/3192576-18.patch"

--- a/drupal/recipes/wunder_next_setup/config/redirect.settings.yml
+++ b/drupal/recipes/wunder_next_setup/config/redirect.settings.yml
@@ -1,4 +1,4 @@
-auto_redirect: false
+auto_redirect: true
 default_status_code: 301
 passthrough_querystring: true
 warning: false


### PR DESCRIPTION
This PR fixes the limitation that we saw in this previous PR around multilingual redirects: https://github.com/wunderio/next4drupal-project/pull/30

We were already using a patch for the decoupled router module, the latest version fixes the issue: https://www.drupal.org/project/decoupled_router/issues/3111456

Before this last version of the patch, if a redirect was found for a language, the calculated path returned to the frontend did not take into consideration the language requested. This patch fixes it, so we can reactivate the automatic creation of redirects when a path is updated. Since paths are tied to titles, this is very common.

## To test locally
1. rebuild the environment if testing locally using the big command
1. log into the backend
1. pick a content item, visit it on the frontend, take note of the path
1. change the title of the content, save. A new redirect should be automaticaly created
1. visit the old path in the frontend, you should be redirected automatically to the new path

## To test in silta

I have done the above, now this page: https://feature-nex-38-redirects-next.next4drupal.dev.wdr.io/fi/terveydenhuolto (that was the old url) should redirect to the new version https://feature-nex-38-redirects-next.next4drupal.dev.wdr.io/fi/terveydenhuolto-new 


