### PR TITLE
NEX-106: Remove our custom hook to assign role on register, use the proper registration_role module

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -33,6 +33,7 @@
         "drupal/next": "^1.6",
         "drupal/paragraphs": "^1.16",
         "drupal/redirect": "^1.9",
+        "drupal/registration_role": "^2.0",
         "drupal/require_login": "^3.0",
         "drupal/restui": "^1.21",
         "drupal/simple_sitemap": "^4.1",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1b1783034ea86fd6e67cccd9418a45c",
+    "content-hash": "3960d0c90923bad76ba8e5788d114a32",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2781,6 +2781,70 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
+            }
+        },
+        {
+            "name": "drupal/registration_role",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/registration_role.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/registration_role-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "3d3b9d1068e80a47e14e0e1d64498bf1e0d3075c"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1689039865",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "karthikeyan-manivasagam",
+                    "homepage": "https://www.drupal.org/user/1494424"
+                },
+                {
+                    "name": "melon",
+                    "homepage": "https://www.drupal.org/user/32875"
+                },
+                {
+                    "name": "mlncn",
+                    "homepage": "https://www.drupal.org/user/64383"
+                },
+                {
+                    "name": "pfournier",
+                    "homepage": "https://www.drupal.org/user/160468"
+                },
+                {
+                    "name": "pignaz",
+                    "homepage": "https://www.drupal.org/user/471908"
+                },
+                {
+                    "name": "yogen.prasad",
+                    "homepage": "https://www.drupal.org/user/2115328"
+                }
+            ],
+            "description": "Automatically assign a role to all new users who register.",
+            "homepage": "https://www.drupal.org/project/registration_role",
+            "support": {
+                "source": "https://git.drupalcode.org/project/registration_role"
             }
         },
         {

--- a/drupal/recipes/wunder_next_setup/recipe.yml
+++ b/drupal/recipes/wunder_next_setup/recipe.yml
@@ -15,6 +15,7 @@ install:
   - redirect
   - require_login
   - webform_rest
+  - registration_role
 config:
   import:
     redirect: '*'

--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -9,7 +9,6 @@ use Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition;
 use Drupal\Core\Site\Settings;
 use Drupal\simple_oauth\Entities\AccessTokenEntity;
 use Drupal\user\Entity\User;
-use Drupal\user\UserInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_load().
@@ -98,31 +97,4 @@ function wunder_next_simple_oauth_private_claims_alter(&$private_claims, AccessT
     'email' => $user->getEmail(),
     'username' => $user->getAccountName(),
   ];
-}
-
-/**
- * Implements hook_ENTITY_TYPE_presave() for user entities.
- */
-function wunder_next_user_presave(UserInterface $user) {
-  // At this time, the registration_role module has not yet
-  // been updated for Drupal 10, so we are adding our custom
-  // role by hand here, by implementing this hook.
-  // Do not assign the roles by default.
-  $assign_roles = FALSE;
-
-  // Get the current user id.
-  $current_user_id = \Drupal::currentUser()->id();
-  if ($current_user_id == 0 && PHP_SAPI !== 'cli') {
-    // If the current user id is 0, then this user is
-    // self-registrating, so ask the module to assign
-    // roles, if applicable.
-    $assign_roles = TRUE;
-  }
-
-  if ($user->isNew() && $assign_roles) {
-    // Add the frontend_login role to the user.
-    // This is currently hardcoded, but it should instead
-    // be a setting for the registration_role module.
-    $user->addRole('frontend_login');
-  }
 }


### PR DESCRIPTION
We used to have a custom hook to assign automatically a role to users that registered trough the site. Now the `registration_role` module has a proper d10 release, so we can remove our custom code and use the contrib module instead.