### PR TITLE
NEX-110: Improvements for registration and logging in

### DIFF
--- a/drupal/recipes/wunder_next_setup/config/registration_role.setting.yml
+++ b/drupal/recipes/wunder_next_setup/config/registration_role.setting.yml
@@ -1,0 +1,3 @@
+role_to_select:
+  frontend_login: frontend_login
+registration_mode: user

--- a/drupal/recipes/wunder_next_setup/recipe.yml
+++ b/drupal/recipes/wunder_next_setup/recipe.yml
@@ -35,3 +35,12 @@ config:
         label: 'Anonymous user'
       grantPermissions:
         - 'restful post user_registration'
+    # Set email messages for user registration:
+    user.mail:
+      simple_config_update:
+        register_no_approval_required:
+          subject: 'Account details for [user:display-name] at [site:name]'
+          body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [wunder_next:frontend-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
+        register_admin_created:
+          subject: 'An administrator created an account for you at [site:name]'
+          body: "[user:display-name],\r\n\r\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [wunder_next:frontend-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"

--- a/drupal/web/modules/custom/wunder_next/wunder_next.module
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.module
@@ -6,7 +6,10 @@
  */
 
 use Drupal\ckeditor5\Plugin\CKEditor5PluginDefinition;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Site\Settings;
+use Drupal\Core\Url;
 use Drupal\simple_oauth\Entities\AccessTokenEntity;
 use Drupal\user\Entity\User;
 
@@ -97,4 +100,80 @@ function wunder_next_simple_oauth_private_claims_alter(&$private_claims, AccessT
     'email' => $user->getEmail(),
     'username' => $user->getAccountName(),
   ];
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function wunder_next_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $account = Drupal::currentUser();
+  if ($account->hasRole('frontend_login')) {
+    // Do not allow the user to change the email address.
+    $form["account"]["mail"]["#access"] = FALSE;
+    // Add textual explanation:
+    $form["#prefix"] = t("Welcome, set your password below:");
+    foreach (array_keys($form['actions']) as $action) {
+      if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+        $form['actions'][$action]['#submit'][] = 'wunder_next_form_user_edited_form_submit';
+      }
+    }
+  }
+}
+
+/**
+ * Additional form submit function for the user form.
+ *
+ * This function will redirect the user to the frontend login page after they
+ * have updated their password.
+ */
+function wunder_next_form_user_edited_form_submit(array $form, FormStateInterface $form_state) {
+  // We don't want the user to keep being logged into Drupal after this
+  // operation goes through, because they will be taken to the frontend anyway:
+  user_logout();
+  $settings = Settings::get('wunder_next.settings');
+  $current_language = Drupal::languageManager()->getCurrentLanguage()->getId();
+  // We will pass two query parameters to the login page in the frontend:
+  $query = [
+    // This parameter is then picked up in the frontend to show
+    // a confirmation message:
+    'passwordJustUpdated' => 'true',
+    // This parameter will redirect the user to their dashboard after login:
+    'callbackUrl' => '/' . $current_language . '/dashboard',
+  ];
+  $frontend_login_url = Url::fromUri($settings['frontend_url'] . '/' . $current_language . '/auth/login', ['query' => $query]);
+  // Redirect to the frontend login url:
+  $response = new TrustedRedirectResponse($frontend_login_url->toString());
+  $form_state->setResponse($response);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function wunder_next_form_user_pass_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // We add our own submit function that will redirect the user to
+  // the frontend after they asked for a new password:
+  $form['#submit'][] = 'wunder_next_form_user_reset_password_form_submit';
+}
+
+/**
+ * Additional form submit function for the user reset password form.
+ *
+ * This function will redirect the user to the frontend login page after they
+ * have requested a new password.
+ */
+function wunder_next_form_user_reset_password_form_submit(array $form, FormStateInterface $form_state) {
+  $settings = Settings::get('wunder_next.settings');
+  $current_language = Drupal::languageManager()->getCurrentLanguage()->getId();
+  // We will pass two query parameters to the login page in the frontend:
+  $query = [
+    // This parameter is then picked up in the frontend to show
+    // a confirmation message:
+    'newPasswordRequested' => 'true',
+    // Add the requested email, so we can display it in the frontend:
+    'enteredEmail' => $form_state->getValue('name'),
+  ];
+  $frontend_login_url = Url::fromUri($settings['frontend_url'] . '/' . $current_language . '/auth/login', ['query' => $query]);
+  // Redirect to the frontend login url:
+  $response = new TrustedRedirectResponse($frontend_login_url->toString());
+  $form_state->setResponse($response);
 }

--- a/drupal/web/modules/custom/wunder_next/wunder_next.tokens.inc
+++ b/drupal/web/modules/custom/wunder_next/wunder_next.tokens.inc
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Tokens for the Wunder next module.
+ */
+
+use Drupal\Core\Site\Settings;
+
+/**
+ * Implements hook_token_info().
+ */
+function wunder_next_token_info() {
+  $info = [];
+  $info['types']['wunder_next'] = [
+    'name' => t('Wunder next tokens'),
+    'description' => t('Tokens needed for the Wunder next module'),
+  ];
+  $info['tokens']['wunder_next']['frontend-url'] = [
+    'name' => t("Link to the frontend site"),
+    'description' => t('The url of the frontend site.'),
+  ];
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function wunder_next_tokens($type, $tokens, array $data, array $options, $bubbleable_metadata) {
+  $replacements = [];
+  $settings = Settings::get('wunder_next.settings');
+  if ($type == 'wunder_next') {
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'frontend-url':
+          $replacements[$original] = $settings['frontend_url'];
+          break;
+      }
+    }
+  }
+  return $replacements;
+}

--- a/next/components/error-required.tsx
+++ b/next/components/error-required.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from "next-i18next";
+
+export function ErrorRequired({
+  fieldTranslatedLabelKey,
+}: {
+  fieldTranslatedLabelKey: string;
+}) {
+  const { t } = useTranslation();
+  const translatedFieldLabel = t(fieldTranslatedLabelKey);
+  return (
+    <span role="alert" className="text-error">
+      {t("field-is-required", { field: translatedFieldLabel })}
+    </span>
+  );
+}

--- a/next/pages/api/auth/[...nextauth].ts
+++ b/next/pages/api/auth/[...nextauth].ts
@@ -13,7 +13,7 @@ export const authOptions: NextAuthOptions = {
     CredentialsProvider({
       name: "Drupal",
       credentials: {
-        username: { label: "Email", type: "text", placeholder: "email" },
+        username: { label: "Username", type: "text", placeholder: "Username" },
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {

--- a/next/pages/api/auth/[...nextauth].ts
+++ b/next/pages/api/auth/[...nextauth].ts
@@ -3,8 +3,6 @@ import NextAuth from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import jwt_decode from "jwt-decode";
 
-import { drupal } from "@/lib/drupal/drupal-client";
-
 import { env } from "@/env";
 
 export const authOptions: NextAuthOptions = {
@@ -15,7 +13,7 @@ export const authOptions: NextAuthOptions = {
     CredentialsProvider({
       name: "Drupal",
       credentials: {
-        username: { label: "Username", type: "text", placeholder: "Username" },
+        username: { label: "Email", type: "text", placeholder: "email" },
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
@@ -26,15 +24,17 @@ export const authOptions: NextAuthOptions = {
         formData.append("username", credentials.username);
         formData.append("password", credentials.password);
 
-        const url = drupal.buildUrl("/oauth/token");
         // Get access token from Drupal.
-        const response = await drupal.fetch(url.toString(), {
-          method: "POST",
-          body: formData,
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
+        const response = await fetch(
+          `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/oauth/token`,
+          {
+            method: "POST",
+            body: formData,
+            headers: {
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
           },
-        });
+        );
 
         if (!response.ok) {
           return null;
@@ -45,15 +45,22 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async jwt({ token, user, account }) {
+    jwt: async function ({ token, user, account, trigger }) {
       if (account && user) {
         token.accessToken = user.access_token;
         token.accessTokenExpires = Date.now() + user.expires_in * 1000;
         token.refreshToken = user.refresh_token;
       }
 
+      // If the client is asking for a refresh of the session,
+      // refresh the access token to get fresh info.
+      if (trigger === "update") {
+        return refreshAccessToken(token);
+      }
+
       // If token has not expired, return it,
-      if (Date.now() < Number(token.accessTokenExpires)) {
+      // @ts-ignore
+      if (Date.now() < token.accessTokenExpires) {
         return token;
       }
 
@@ -87,15 +94,16 @@ async function refreshAccessToken(token) {
     formData.append("client_secret", env.DRUPAL_CLIENT_SECRET);
     formData.append("refresh_token", token.refreshToken);
 
-    const url = drupal.buildUrl("/oauth/token");
-
-    const response = await drupal.fetch(url.toString(), {
-      method: "POST",
-      body: formData,
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
+    const response = await fetch(
+      `${env.NEXT_PUBLIC_DRUPAL_BASE_URL}/oauth/token`,
+      {
+        method: "POST",
+        body: formData,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
       },
-    });
+    );
 
     const data = await response.json();
 

--- a/next/pages/api/register.ts
+++ b/next/pages/api/register.ts
@@ -2,6 +2,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { drupal } from "@/lib/drupal/drupal-client";
 
+import siteConfig from "@/site.config";
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
@@ -11,12 +13,20 @@ export default async function handler(
       const url = drupal.buildUrl("/user/register?_format=json");
       const body = JSON.parse(req.body);
 
+      // The locale is passed in this header:
+      const localeHeader = req.headers["accept-language"];
+
       // Do a call to drupal to register the user:
       const result = await drupal.fetch(url.toString(), {
         method: "POST",
         body: JSON.stringify({
           name: [{ value: body.name }],
           mail: [{ value: body.mail }],
+          preferred_langcode: [
+            {
+              value: localeHeader || siteConfig.defaultLocale,
+            },
+          ],
         }),
         headers: {
           "Content-Type": "application/json",
@@ -26,16 +36,17 @@ export default async function handler(
         withAuth: false,
       });
 
-      if (result.ok) {
-        res.status(200).end();
-      } else {
-        console.error("Sign-up failed:", result);
-        res.status(result.status).end();
-        throw new Error();
+      if (!result.ok) {
+        res.status(result.status).json({ error: result.statusText });
+        const message = `Error registering user: ${result.status}: ${result.statusText}`;
+        throw new Error(message);
       }
+      //The operation was successful:
+      res.status(200).json({ success: true });
     }
   } catch (error) {
-    console.error("Sign-up POST failed:", error);
-    return res.status(400).json(error.message);
+    console.error("Fetch error:", JSON.stringify(error.message, null, 2));
+    // Respond with an appropriate error status code or message
+    res.status(500).json({ error: error.message });
   }
 }

--- a/next/pages/auth/login.tsx
+++ b/next/pages/auth/login.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "next-i18next";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 
-import { HeadingPage } from "@/components/heading--page";
+import { ErrorRequired } from "@/components/error-required";
 import { Meta } from "@/components/meta";
 import { getCommonPageProps } from "@/lib/get-common-page-props";
 
@@ -22,7 +22,11 @@ type Inputs = {
 export default function LogIn() {
   const { callbackUrl, error } = useRouter().query;
   const { t } = useTranslation();
-  const { register, handleSubmit } = useForm<Inputs>();
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<Inputs>();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const onSubmit = async ({ username, password }: Inputs) => {
@@ -38,36 +42,47 @@ export default function LogIn() {
   return (
     <>
       <Meta title={t("log-in")} metatags={[]} />
-
-      <HeadingPage>{t("log-in")}</HeadingPage>
-      <div className="max-w-md py-4">
+      <div className="max-w-md pb-16 pt-8 font-work">
         {error && (
           <StatusMessage level="error" className="mb-8">
             {t("login-error-check-username-password")}
           </StatusMessage>
         )}
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
-          <div>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex w-full max-w-2xl flex-col"
+        >
+          <div className="mb-6">
             <Label htmlFor="username">{t("username")}</Label>
             <Input
               id="username"
               autoComplete="username"
+              aria-invalid={errors.username ? "true" : "false"}
               {...register("username", {
                 required: true,
               })}
+              className="inset-0 h-12 w-full rounded border border-neu-200 p-2 text-body-sm text-neu-400 ring-offset-4 focus:ring-4"
             />
+            {errors.username && errors.username.type === "required" && (
+              <ErrorRequired fieldTranslatedLabelKey={"username"} />
+            )}
           </div>
 
-          <div>
+          <div className="mb-6">
             <Label htmlFor="password">{t("password")}</Label>
             <Input
               id="password"
               autoComplete="current-password"
               type="password"
+              aria-invalid={errors.password ? "true" : "false"}
               {...register("password", {
                 required: true,
               })}
+              className="inset-0 h-12 w-full rounded border border-neu-200 p-2 text-body-sm text-neu-400 ring-offset-4 focus:ring-4"
             />
+            {errors.password && errors.password.type === "required" && (
+              <ErrorRequired fieldTranslatedLabelKey={"password"} />
+            )}
           </div>
 
           <Button type="submit" disabled={isSubmitting}>

--- a/next/pages/auth/login.tsx
+++ b/next/pages/auth/login.tsx
@@ -1,4 +1,5 @@
 import type { GetStaticPropsContext } from "next";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { signIn } from "next-auth/react";
 import { useTranslation } from "next-i18next";
@@ -9,6 +10,7 @@ import { ErrorRequired } from "@/components/error-required";
 import { Meta } from "@/components/meta";
 import { getCommonPageProps } from "@/lib/get-common-page-props";
 
+import { env } from "@/env";
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
 import { Label } from "@/ui/label";
@@ -28,6 +30,11 @@ export default function LogIn() {
     handleSubmit,
   } = useForm<Inputs>();
 
+  const router = useRouter();
+  const isPasswordUpdated = Boolean(router.query.passwordJustUpdated) || false;
+  const isPasswordRequested =
+    Boolean(router.query.newPasswordRequested) || false;
+  const enteredEmail = router.query.enteredEmail || "";
   const [isSubmitting, setIsSubmitting] = useState(false);
   const onSubmit = async ({ username, password }: Inputs) => {
     setIsSubmitting(true);
@@ -39,10 +46,23 @@ export default function LogIn() {
     setIsSubmitting(false);
   };
 
+  const resetPasswordBackendUrl =
+    env.NEXT_PUBLIC_DRUPAL_BASE_URL + "/" + router.locale + "/user/password";
+
   return (
     <>
       <Meta title={t("log-in")} metatags={[]} />
       <div className="max-w-md pb-16 pt-8 font-work">
+        {isPasswordUpdated && (
+          <StatusMessage level="success" className="mb-8">
+            {t("password-updated-login-below")}
+          </StatusMessage>
+        )}
+        {isPasswordRequested && (
+          <StatusMessage level="info" className="mb-8">
+            {t("password-reset-check-your-email", { email: enteredEmail })}
+          </StatusMessage>
+        )}
         {error && (
           <StatusMessage level="error" className="mb-8">
             {t("login-error-check-username-password")}
@@ -89,6 +109,9 @@ export default function LogIn() {
             {t("log-in")}
           </Button>
         </form>
+        <Link className="inline-block mt-2" href={resetPasswordBackendUrl}>
+          {t("reset-your-password")}
+        </Link>
       </div>
     </>
   );

--- a/next/public/locales/en/common.json
+++ b/next/public/locales/en/common.json
@@ -75,5 +75,6 @@
   "image-of": "Image of {{name}}",
   "all-articles": "All articles",
   "downloadable-files": "List of downloadable files",
-  "download": "Download"
+  "download": "Download",
+  "field-is-required": "The {{field}} field is required."
 }

--- a/next/public/locales/en/common.json
+++ b/next/public/locales/en/common.json
@@ -76,5 +76,8 @@
   "all-articles": "All articles",
   "downloadable-files": "List of downloadable files",
   "download": "Download",
+  "password-updated-login-below": "Your password has been updated. Please log in below.",
+  "password-reset-check-your-email": "If {{email}} was associated with a actual account, check your email for a link to reset your password.",
+  "reset-your-password": "Reset your password",
   "field-is-required": "The {{field}} field is required."
 }

--- a/next/public/locales/fi/common.json
+++ b/next/public/locales/fi/common.json
@@ -76,5 +76,8 @@
   "image-of": "Kuva: {{name}}",
   "downloadable-files": "Ladattavien tiedostojen luettelo",
   "download": "Lataa",
+  "password-reset-check-your-email": "Jos {{email}} oli liitetty oikeaan tiliin, tarkista sähköpostistasi linkki salasanan vaihtamiseen.",
+  "password-updated-login-below": "Salasanasi on päivitetty. Voit kirjautua sisään alla olevalla lomakkeella.",
+  "reset-your-password": "Nollaa salasanasi",
   "field-is-required": "'{{field}}' kenttä on pakollinen"
 }

--- a/next/public/locales/fi/common.json
+++ b/next/public/locales/fi/common.json
@@ -75,5 +75,6 @@
   "modal-close": "Sulje",
   "image-of": "Kuva: {{name}}",
   "downloadable-files": "Ladattavien tiedostojen luettelo",
-  "download": "Lataa"
+  "download": "Lataa",
+  "field-is-required": "'{{field}}' kenttä on pakollinen"
 }

--- a/next/public/locales/sv/common.json
+++ b/next/public/locales/sv/common.json
@@ -76,5 +76,8 @@
   "all-articles": "Alla artiklar",
   "downloadable-files": "Lista över nedladdningsbara filer",
   "download": "Ladda ner",
+  "password-updated-login-below": "Ditt lösenord har uppdaterats. Du kan logga in med formuläret nedan.",
+  "password-reset-check-your-email": "Om {{email}} var associerad med ett faktiskt konto, kontrollera din e-post efter en länk för att återställa ditt lösenord.",
+  "reset-your-password": "Återställ ditt lösenord",
   "field-is-required": "{{field}} är obligatoriskt."
 }

--- a/next/public/locales/sv/common.json
+++ b/next/public/locales/sv/common.json
@@ -75,5 +75,6 @@
   "image-of": "Bild av {{name}}",
   "all-articles": "Alla artiklar",
   "downloadable-files": "Lista över nedladdningsbara filer",
-  "download": "Ladda ner"
+  "download": "Ladda ner",
+  "field-is-required": "{{field}} är obligatoriskt."
 }


### PR DESCRIPTION
This PR improves the workflow for user registration and resetting of the password:

1. validation of register and login form
2. add token for the frontend login url
3. add email messages with the token to direct users to the frontend site
4. add redirects to the frontend after a password is chosen or reset
5. add messages to the user in the frontend regarding the various operations
6. add redirect to dashboard after logging in after password has been reset

Easier to show in a video: 


https://github.com/wunderio/next4drupal-project/assets/185412/06fe7bfa-b82b-4932-a053-e65cb54dd794


